### PR TITLE
Vmo 2926 match flow builder toolbar actions with voto5 -- extend toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-vue": "^6.2.2",
     "node-sass": "^4.14.1",
     "sass-loader": "^8.0.2",
+    "storybook-vue-router": "^1.0.7",
     "ts-vue-plugin": "^0.1.2",
     "typescript": "~3.9.3",
     "vue-cli-plugin-storybook": "~1.2.2",

--- a/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
+++ b/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
@@ -161,23 +161,7 @@
                     @click="attemptSaveTree">
               {{saveButtonText}}
             </button>
-
-            <template v-if="isFeatureTreeSendEnabled">
-              <a v-if="can('edit-content')"
-                 :href="publishVersionUrl"
-                 class="btn btn-success"
-                 :disabled="isTreeSaving || !isTreeValid"
-                 :title="isTreeValid ? 'flow-builder.publish-this-version-of-the-flow' : 'flow-builder.fix-validation-errors-before-publishing' | trans">
-                {{'flow-builder.publish' | trans}}
-              </a>
-              <a v-if="can('send-outgoing-call')"
-                 :href="sendOutgoingCallUrl"
-                 class="btn btn-success tree-send-tree-call"
-                 :disabled="isTreeSaving || !isTreeValid"
-                 :title="trans('flow-builder.schedule-and-send-an-outgoing-call')">
-                {{trans('flow-builder.send')}}
-              </a>
-            </template>
+            <slot name="right-grouped-buttons"/>
           </div>
         </div>
       </div>

--- a/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
+++ b/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
@@ -207,6 +207,7 @@
         'isFeatureTreeDuplicateEnabled',
         'isFeatureViewResultsEnabled',
         'isFeatureUpdateInteractionTotalsEnabled',
+        'isResourceEditorEnabled',
       ]),
 
       flow: {
@@ -227,10 +228,6 @@
                 ['platform_metadata', 'io_viamo']
             ))
         }
-      },
-
-      isResourceEditorEnabled() {
-        return false
       },
 
       jsKey() { // deprecate

--- a/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
+++ b/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
@@ -30,15 +30,7 @@
             </router-link>
           </div>
 
-          <template v-if="ui.isEditableLocked">
-            <a v-if="isFeatureViewResultsEnabled"
-               :href="viewResultsUrl"
-               :title="trans('flow-builder.view-results')"
-               class="btn btn-default">
-              <span class="glyphicon glyphicon-signal"></span>
-            </a>
-          </template>
-          <a v-else
+          <a v-if="!ui.isEditableLocked"
              :href="editOrViewTreeJsUrl"
              :title="trans('flow-builder.click-to-toggle-editing')"
              class="btn btn-default"
@@ -46,15 +38,6 @@
              @click="attemptSaveTree">
             {{trans('flow-builder.edit-flow')}}
           </a>
-
-          <a v-if="!ui.isEditable && isFeatureTreeDuplicateEnabled"
-             :href="duplicateTreeLink"
-             class="btn btn-default"
-             :title="trans('flow-builder.duplicate-entire-flow')">
-            <span class="glyphicon glyphicon-tags"/>
-          </a>
-
-          <!--        <interaction-totals-date-range-configuration v-if="ui.isEditableLocked && isFeatureUpdateInteractionTotalsEnabled"/>-->
 
           <div v-if="ui.isEditable" class="btn-group">
             <button type="button"
@@ -151,6 +134,8 @@
                   :disabled="!activeBlockId">
             {{trans('flow-builder.delete')}}
           </button>
+
+          <slot name="extra-buttons"/>
 
           <div class="btn-group pull-right">
             <button v-if="ui.isEditable && isFeatureTreeSaveEnabled"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,7 +5,7 @@ import {routes as treesRoutes} from './trees'
 
 Vue.use(VueRouter);
 
-const routes: Array<RouteConfig> = [
+export const routes: Array<RouteConfig> = [
   // todo: rename trees module + url path to builder + add extensible children as intx-design & resource-viewer
   ...treesRoutes,
 ];

--- a/src/store/trees/trees.js
+++ b/src/store/trees/trees.js
@@ -311,6 +311,18 @@ export default {
     	ui.isEditable = value
 		},
 
+    addEnabledFeature({ui}, {value}) {
+      if (ui.enabledFeatures.indexOf(value) < 0) {
+        ui.enabledFeatures.push(value);
+      }
+    },
+
+    removeEnabledFeature({ui}, {value}) {
+      if (ui.enabledFeatures.indexOf(value) > -1) {
+        ui.enabledFeatures = ui.enabledFeatures.filter((item) => item !== value)
+      }
+    },
+
 		setContentTypeEnabled({tree}, {contentType, isEnabled}) {
 			tree[`has${lodash.upperFirst(contentType)}`] = +isEnabled
     },

--- a/src/store/trees/trees.js
+++ b/src/store/trees/trees.js
@@ -78,6 +78,7 @@ export default {
     isFeatureTreeDuplicateEnabled: ({ui}) => lodash.find(ui.enabledFeatures, feature => feature === 'treeDuplicate'),
     isFeatureTreeViewVersionsEnabled: ({ui}) => lodash.find(ui.enabledFeatures, feature => feature === 'treeViewVersions'),
     isFeatureTreeDuplicateOfEnabled: ({ui}) => lodash.find(ui.enabledFeatures, feature => feature === 'treeDuplicateOf'),
+    isResourceEditorEnabled: ({ui}) => lodash.find(ui.enabledFeatures, feature => feature === 'resourceEditor'),
     isFeatureUpdateInteractionTotalsEnabled: ({ui}) => lodash.find(ui.enabledFeatures, feature => feature === 'updateInteractionTotals'),
     isFeatureAudioUploadEnabled: ({ui}) => lodash.find(ui.enabledFeatures, feature => feature === 'audioUpload'),
     isFeatureViewResultsEnabled: ({ui}) => lodash.find(ui.enabledFeatures, feature => feature === 'viewResults'),

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -78,3 +78,40 @@ class CurrentClass3 extends BaseMountedClass {
   @Mutation removeEnabledFeature: any
 }
 export const WithSaveFlow = () => (CurrentClass3)
+
+// With Extra right grouped button
+let BaseOptions2 = BaseOptions
+BaseOptions2.template = `
+  <flow-builder-container>
+    <tree-builder-toolbar>
+      <template slot="right-grouped-buttons">
+        <a href="#"
+           class="btn btn-success"
+           :disabled="true"
+           title="another grouped button">
+           Action X
+        </a>
+        <a href="#"
+           class="btn btn-warning"
+           :disabled="false"
+           title="another grouped button">
+           Action Y
+        </a>
+      </template>
+    </tree-builder-toolbar>
+  </flow-builder-container>`
+@Component<any>(
+  {
+    ...BaseOptions,
+    async mounted() {
+      this.updateIsEditable({value: 1})
+      this.addEnabledFeature({value: 'treeSave'})
+    }
+  }
+)
+class CurrentClass4 extends BaseMountedClass {
+  @Mutation updateIsEditable: any
+  @Mutation addEnabledFeature: any
+  @Mutation removeEnabledFeature: any
+}
+export const WithGroupedButtonsSlot = () => (CurrentClass4)

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -51,6 +51,21 @@ class DefaultClass extends BaseMountedClass {
 }
 export const Default = () => (DefaultClass)
 
+// Without Resource Editor toggle
+@Component<any>(
+  {
+    ...BaseOptions,
+    async mounted() {
+      this.updateIsEditable({value: 0})
+      this.removeEnabledFeature({value: 'resourceEditor'})
+    }
+  }
+)
+class ResourceEditorClass extends BaseMountedClass {
+
+}
+export const WithoutResourceEditorToggle = () => (ResourceEditorClass)
+
 // Edit flow
 @Component<any>(
   {
@@ -82,21 +97,6 @@ class SaveClass extends BaseMountedClass {
 
 }
 export const WithSaveButton = () => (SaveClass)
-
-// With Resource Editor toggle
-@Component<any>(
-  {
-    ...BaseOptions,
-    async mounted() {
-      this.updateIsEditable({value: 0})
-      this.addEnabledFeature({value: 'resourceEditor'})
-    }
-  }
-)
-class ResourceEditorClass extends BaseMountedClass {
-
-}
-export const WithResourceEditorToggle = () => (ResourceEditorClass)
 
 // With Extra right grouped button
 let BaseOptions2 = BaseOptions

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -62,7 +62,7 @@ class CurrentClass2 extends BaseMountedClass {
 }
 export const EditFlow = () => (CurrentClass2)
 
-// With Save flow
+// With Save button
 @Component<any>(
   {
     ...BaseOptions,
@@ -77,7 +77,7 @@ class CurrentClass3 extends BaseMountedClass {
   @Mutation addEnabledFeature: any
   @Mutation removeEnabledFeature: any
 }
-export const WithSaveFlow = () => (CurrentClass3)
+export const WithSaveButton = () => (CurrentClass3)
 
 // With Extra right grouped button
 let BaseOptions2 = BaseOptions

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -115,3 +115,40 @@ class CurrentClass4 extends BaseMountedClass {
   @Mutation removeEnabledFeature: any
 }
 export const WithGroupedButtonsSlot = () => (CurrentClass4)
+
+// With Extra buttons
+let BaseOptions3 = BaseOptions
+BaseOptions3.template = `
+  <flow-builder-container>
+    <tree-builder-toolbar>
+      <template slot="extra-buttons">
+        <a href="#"
+           class="btn btn-success"
+           :disabled="true"
+           title="another grouped button">
+           Action X
+        </a>
+        <a href="#"
+           class="btn btn-warning"
+           :disabled="false"
+           title="another grouped button">
+           Action Y
+        </a>
+      </template>
+    </tree-builder-toolbar>
+  </flow-builder-container>`
+@Component<any>(
+  {
+    ...BaseOptions,
+    async mounted() {
+      this.updateIsEditable({value: 1})
+      this.addEnabledFeature({value: 'treeSave'})
+    }
+  }
+)
+class CurrentClass5 extends BaseMountedClass {
+  @Mutation updateIsEditable: any
+  @Mutation addEnabledFeature: any
+  @Mutation removeEnabledFeature: any
+}
+export const WithExtraButtonsSlot = () => (CurrentClass5)

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -30,6 +30,10 @@ const BaseOptions = {
 }
 class BaseMountedClass extends Vue {
   @Action initializeTreeModel: any
+
+  @Mutation updateIsEditable: any
+  @Mutation addEnabledFeature: any
+  @Mutation removeEnabledFeature: any
 }
 
 // Default
@@ -38,13 +42,14 @@ class BaseMountedClass extends Vue {
         ...BaseOptions,
       async mounted() {
         this.updateIsEditable({value: 0})
+        this.addEnabledFeature({value: 'resourceEditor'})
       }
     }
 )
-class CurrentClass extends BaseMountedClass {
-  @Mutation updateIsEditable: any
+class DefaultClass extends BaseMountedClass {
+
 }
-export const Default = () => (CurrentClass)
+export const Default = () => (DefaultClass)
 
 // Edit flow
 @Component<any>(
@@ -52,15 +57,15 @@ export const Default = () => (CurrentClass)
     ...BaseOptions,
     async mounted() {
       this.updateIsEditable({value: 1})
+      this.addEnabledFeature({value: 'resourceEditor'})
       this.removeEnabledFeature({value: 'treeSave'})
     }
   }
 )
-class CurrentClass2 extends BaseMountedClass {
-  @Mutation updateIsEditable: any
-  @Mutation removeEnabledFeature: any
+class EditFlowClass extends BaseMountedClass {
+
 }
-export const EditFlow = () => (CurrentClass2)
+export const EditFlow = () => (EditFlowClass)
 
 // With Save button
 @Component<any>(
@@ -68,16 +73,30 @@ export const EditFlow = () => (CurrentClass2)
     ...BaseOptions,
     async mounted() {
       this.updateIsEditable({value: 1})
+      this.addEnabledFeature({value: 'resourceEditor'})
       this.addEnabledFeature({value: 'treeSave'})
     }
   }
 )
-class CurrentClass3 extends BaseMountedClass {
-  @Mutation updateIsEditable: any
-  @Mutation addEnabledFeature: any
-  @Mutation removeEnabledFeature: any
+class SaveClass extends BaseMountedClass {
+
 }
-export const WithSaveButton = () => (CurrentClass3)
+export const WithSaveButton = () => (SaveClass)
+
+// With Resource Editor toggle
+@Component<any>(
+  {
+    ...BaseOptions,
+    async mounted() {
+      this.updateIsEditable({value: 0})
+      this.addEnabledFeature({value: 'resourceEditor'})
+    }
+  }
+)
+class ResourceEditorClass extends BaseMountedClass {
+
+}
+export const WithResourceEditorToggle = () => (ResourceEditorClass)
 
 // With Extra right grouped button
 let BaseOptions2 = BaseOptions
@@ -105,16 +124,15 @@ BaseOptions2.template = `
     ...BaseOptions,
     async mounted() {
       this.updateIsEditable({value: 1})
+      this.addEnabledFeature({value: 'resourceEditor'})
       this.addEnabledFeature({value: 'treeSave'})
     }
   }
 )
-class CurrentClass4 extends BaseMountedClass {
-  @Mutation updateIsEditable: any
-  @Mutation addEnabledFeature: any
-  @Mutation removeEnabledFeature: any
+class GroupButtonsSlotClass extends BaseMountedClass {
+
 }
-export const WithGroupedButtonsSlot = () => (CurrentClass4)
+export const WithGroupedButtonsSlot = () => (GroupButtonsSlotClass)
 
 // With Extra buttons
 let BaseOptions3 = BaseOptions
@@ -142,13 +160,12 @@ BaseOptions3.template = `
     ...BaseOptions,
     async mounted() {
       this.updateIsEditable({value: 1})
+      this.addEnabledFeature({value: 'resourceEditor'})
       this.addEnabledFeature({value: 'treeSave'})
     }
   }
 )
-class CurrentClass5 extends BaseMountedClass {
-  @Mutation updateIsEditable: any
-  @Mutation addEnabledFeature: any
-  @Mutation removeEnabledFeature: any
+class ExtraButtonsSlotClass extends BaseMountedClass {
+  
 }
-export const WithExtraButtonsSlot = () => (CurrentClass5)
+export const WithExtraButtonsSlot = () => (ExtraButtonsSlotClass)

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -8,8 +8,6 @@ import {Component} from 'vue-property-decorator'
 import {IRootState, store} from '@/store'
 import TreeBuilderToolbar from "@/components/interaction-designer/toolbar/TreeBuilderToolbar.vue";
 
-import {namespace} from 'vuex-class'
-
 export default {
   title: 'InteractionDesigner/Toolbar',
   // Our exports that end in "Data" are not stories.
@@ -54,10 +52,29 @@ export const Default = () => (CurrentClass)
     ...BaseOptions,
     async mounted() {
       this.updateIsEditable({value: 1})
+      this.removeEnabledFeature({value: 'treeSave'})
     }
   }
 )
 class CurrentClass2 extends BaseMountedClass {
   @Mutation updateIsEditable: any
+  @Mutation removeEnabledFeature: any
 }
 export const EditFlow = () => (CurrentClass2)
+
+// With Save flow
+@Component<any>(
+  {
+    ...BaseOptions,
+    async mounted() {
+      this.updateIsEditable({value: 1})
+      this.addEnabledFeature({value: 'treeSave'})
+    }
+  }
+)
+class CurrentClass3 extends BaseMountedClass {
+  @Mutation updateIsEditable: any
+  @Mutation addEnabledFeature: any
+  @Mutation removeEnabledFeature: any
+}
+export const WithSaveFlow = () => (CurrentClass3)

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -1,7 +1,7 @@
 import Vuex from 'vuex'
 import Vue from 'vue'
 import {
-    Action,
+    Action, Mutation
 } from 'vuex-class'
 import FlowBuilderContainer from "@/stories/story-utils/FlowBuilderContainer.vue";
 import {Component} from 'vue-property-decorator'
@@ -9,10 +9,9 @@ import {IRootState, store} from '@/store'
 import TreeBuilderToolbar from "@/components/interaction-designer/toolbar/TreeBuilderToolbar.vue";
 
 import {namespace} from 'vuex-class'
-const flowVuexNamespace = namespace('flow')
 
 export default {
-  title: 'Toolbar/Toolbar slot extension',
+  title: 'InteractionDesigner/Toolbar',
   // Our exports that end in "Data" are not stories.
   excludeStories: /.*Data$/,
 }
@@ -39,47 +38,26 @@ class BaseMountedClass extends Vue {
 @Component<any>(
     {
         ...BaseOptions,
+      async mounted() {
+        this.updateIsEditable({value: 0})
+      }
     }
 )
-class CurrentClass extends BaseMountedClass {}
+class CurrentClass extends BaseMountedClass {
+  @Mutation updateIsEditable: any
+}
 export const Default = () => (CurrentClass)
 
-//ExistingDataPreFilled
-// @Component<any>(
-//     {
-//         ...BaseOptions,
-//         store: new Vuex.Store<IRootState>(store),
-//         async mounted() {
-//             const {uuid: flowId} = await this.flow_addBlankFlow()
-//             const sampleLanguages: ILanguage[] = [
-//                 {
-//                     id: '1',
-//                     name: "English",
-//                     abbreviation: "EN",
-//                     orgId: "",
-//                     rightToLeft: true,
-//                 },
-//             ]
-//
-//             const sampleModes = [
-//                 SupportedMode.SMS,
-//                 SupportedMode.IVR,
-//                 SupportedMode.RICH_MESSAGING
-//             ]
-//
-//             this.flow_setName({flowId, value: "FlowName"})
-//             this.flow_setLabel({flowId, value: "A flow label"})
-//             this.flow_setInteractionTimeout({flowId, value: 20})
-//             this.flow_setSupportedMode({flowId, value: sampleModes})
-//             this.flow_setLanguages({flowId, value: sampleLanguages})
-//         },
-//     }
-// )
-// class CurrentClass2 extends BaseMountedVueClass {
-//     @flowVuexNamespace.Mutation flow_setName:any
-//     @flowVuexNamespace.Mutation flow_setLabel:any
-//     @flowVuexNamespace.Mutation flow_setInteractionTimeout:any
-//     @flowVuexNamespace.Mutation flow_setSupportedMode:any
-//     @flowVuexNamespace.Mutation flow_setLanguages:any
-// }
-// export const ExistingDataPreFilled = () => (CurrentClass2)
+// Edit flow
+@Component<any>(
+  {
+    ...BaseOptions,
+    async mounted() {
+      this.updateIsEditable({value: 1})
+    }
+  }
+)
+class CurrentClass2 extends BaseMountedClass {
+  @Mutation updateIsEditable: any
+}
+export const EditFlow = () => (CurrentClass2)

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -1,0 +1,85 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+import {
+    Action,
+} from 'vuex-class'
+import FlowBuilderContainer from "@/stories/story-utils/FlowBuilderContainer.vue";
+import {Component} from 'vue-property-decorator'
+import {IRootState, store} from '@/store'
+import TreeBuilderToolbar from "@/components/interaction-designer/toolbar/TreeBuilderToolbar.vue";
+
+import {namespace} from 'vuex-class'
+const flowVuexNamespace = namespace('flow')
+
+export default {
+  title: 'Toolbar/Toolbar slot extension',
+  // Our exports that end in "Data" are not stories.
+  excludeStories: /.*Data$/,
+}
+
+
+const ToolbarTemplate = `
+  <flow-builder-container>
+    <tree-builder-toolbar/>
+  </flow-builder-container>`
+
+const BaseOptions = {
+  components: {FlowBuilderContainer, TreeBuilderToolbar},
+  template: ToolbarTemplate,
+  store: new Vuex.Store<IRootState>(store),
+  created() {
+      this.initializeTreeModel()
+  },
+}
+class BaseMountedClass extends Vue {
+  @Action initializeTreeModel: any
+}
+
+// Default
+@Component<any>(
+    {
+        ...BaseOptions,
+    }
+)
+class CurrentClass extends BaseMountedClass {}
+export const Default = () => (CurrentClass)
+
+//ExistingDataPreFilled
+// @Component<any>(
+//     {
+//         ...BaseOptions,
+//         store: new Vuex.Store<IRootState>(store),
+//         async mounted() {
+//             const {uuid: flowId} = await this.flow_addBlankFlow()
+//             const sampleLanguages: ILanguage[] = [
+//                 {
+//                     id: '1',
+//                     name: "English",
+//                     abbreviation: "EN",
+//                     orgId: "",
+//                     rightToLeft: true,
+//                 },
+//             ]
+//
+//             const sampleModes = [
+//                 SupportedMode.SMS,
+//                 SupportedMode.IVR,
+//                 SupportedMode.RICH_MESSAGING
+//             ]
+//
+//             this.flow_setName({flowId, value: "FlowName"})
+//             this.flow_setLabel({flowId, value: "A flow label"})
+//             this.flow_setInteractionTimeout({flowId, value: 20})
+//             this.flow_setSupportedMode({flowId, value: sampleModes})
+//             this.flow_setLanguages({flowId, value: sampleLanguages})
+//         },
+//     }
+// )
+// class CurrentClass2 extends BaseMountedVueClass {
+//     @flowVuexNamespace.Mutation flow_setName:any
+//     @flowVuexNamespace.Mutation flow_setLabel:any
+//     @flowVuexNamespace.Mutation flow_setInteractionTimeout:any
+//     @flowVuexNamespace.Mutation flow_setSupportedMode:any
+//     @flowVuexNamespace.Mutation flow_setLanguages:any
+// }
+// export const ExistingDataPreFilled = () => (CurrentClass2)

--- a/src/stories/Toolbar.stories.ts
+++ b/src/stories/Toolbar.stories.ts
@@ -7,11 +7,20 @@ import FlowBuilderContainer from "@/stories/story-utils/FlowBuilderContainer.vue
 import {Component} from 'vue-property-decorator'
 import {IRootState, store} from '@/store'
 import TreeBuilderToolbar from "@/components/interaction-designer/toolbar/TreeBuilderToolbar.vue";
+import StoryRouter from 'storybook-vue-router';
+import {routes} from '@/router'
+
+// Allow story to load components which use <router-link>
+const decorators = [() => ({ template: '<div><story/></div>' })];
+decorators.push(StoryRouter({}, {
+  routes
+}))
 
 export default {
   title: 'InteractionDesigner/Toolbar',
   // Our exports that end in "Data" are not stories.
   excludeStories: /.*Data$/,
+  decorators
 }
 
 

--- a/src/stories/story-utils/FlowBuilderContainer.vue
+++ b/src/stories/story-utils/FlowBuilderContainer.vue
@@ -1,0 +1,31 @@
+<template>
+  <div id="viamo-app"
+       class="viamo-app-container flow-builder-sidebar-editor-container">
+    <div class="container-full">
+      <div class="main-content-container">
+        <section id="tree-app">
+          <div id="tree-interaction-designer" class="edit-tree">
+            <div class="interaction-designer-contents panel panel-default">
+              <slot/>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import '@/css/InteractionDesigner.css'
+import '@/css/voto3.css'
+
+import Vue from 'vue'
+import {Component, Prop} from 'vue-property-decorator'
+
+@Component({})
+export class FlowBuilderContainer extends Vue {
+
+}
+
+export default FlowBuilderContainer
+</script>

--- a/src/stories/story-utils/FlowBuilderSidebarEditorContainer.vue
+++ b/src/stories/story-utils/FlowBuilderSidebarEditorContainer.vue
@@ -1,48 +1,41 @@
 <template>
-  <div v-if="block || flow"
-      id="viamo-app" 
-      class="viamo-app-container flow-builder-sidebar-editor-container">
-    <div class="container-full">
-      <div class="main-content-container">
-        <section id="tree-app">
-          <div id="tree-interaction-designer" class="edit-tree">
-            <div class="interaction-designer-contents panel panel-default">
-              <div class="hidden-print hidden-xs hidden-sm tree-sidebar-menu-container">
-                <nav class="bs-docs-sidebar">
-                  <div id="tree-sidebar" class="tree-sidebar-menu">
-                    <div v-if="block" class="tree-sidebar-edit-block"
-                        :data-block-type="block.type"
-                        :data-for-block-id="block.uuid">
-                      <slot/>
-                    </div>
-                    <div v-else-if="flow" class="tree-sidebar-edit-flow"
-                        :data-for-flow-id="flow.uuid">
-                      <slot/>
-                    </div>
-                  </div>
-                </nav>
-              </div>
+  <div>
+    <flow-builder-container v-if="block || flow">
+      <div class="hidden-print hidden-xs hidden-sm tree-sidebar-menu-container">
+        <nav class="bs-docs-sidebar">
+          <div id="tree-sidebar" class="tree-sidebar-menu">
+            <div v-if="block" class="tree-sidebar-edit-block"
+                 :data-block-type="block.type"
+                 :data-for-block-id="block.uuid">
+              <slot/>
+            </div>
+            <div v-else-if="flow" class="tree-sidebar-edit-flow"
+                 :data-for-flow-id="flow.uuid">
+              <slot/>
             </div>
           </div>
-        </section>
+        </nav>
       </div>
-    </div>
+    </flow-builder-container>
   </div>
 </template>
 
 <script lang="ts">
-  import '@/css/InteractionDesigner.css'
-  import '@/css/voto3.css'
-
   import Vue from 'vue'
   import {Component, Prop} from 'vue-property-decorator'
 
-  import {IFlow, IBlock} from '@floip/flow-runner'
+import FlowBuilderContainer from "@/stories/story-utils/FlowBuilderContainer.vue";
+import {IFlow, IBlock} from '@floip/flow-runner'
 
-  @Component({})
-  export class FlowBuilderSidebarEditorContainer extends Vue {
-    @Prop({default: null}) readonly block!: IBlock
-    @Prop({default: null}) readonly flow!: IFlow
+@Component({
+  components: {
+    FlowBuilderContainer
   }
-  export default FlowBuilderSidebarEditorContainer
+})
+export class FlowBuilderSidebarEditorContainer extends Vue {
+  @Prop({default: null}) readonly block!: IBlock
+  @Prop({default: null}) readonly flow!: IFlow
+}
+
+export default FlowBuilderSidebarEditorContainer
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11822,6 +11822,11 @@ store2@^2.7.1:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.11.2.tgz#a298e5e97b21b3ce7419b732540bc7c79cb007db"
   integrity sha512-TQMKs+C6n9idtzLpxluikmDCYiDJrTbbIGn9LFxMg0BVTu+8JZKSlXTWYRpOFKlfKD5HlDWLVpJJyNGZ2e9l1A==
 
+storybook-vue-router@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/storybook-vue-router/-/storybook-vue-router-1.0.7.tgz#366451212149d9d0a32557545b244667bb01768e"
+  integrity sha512-R+DYARQ40YVbMbV5moLDmQvodJX5FQPVy5cULb782P1gD5rAkulWtgt8yrM7pmjYru+LTPdLS4blrFPnWlb0sQ==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
This PR is about to "extend the toolbar component"
I took the opportunity to add toolbar stories, meaning this was branched out of [VMO-2642-move-storybook-stories-from-voto5](https://github.com/FLOIP/flow-builder/tree/VMO-2642-move-storybook-stories-from-voto5)

Therefore, the merge plan is:
- merge vmo-2642 to master
- change the destination of this PR to master, merge it

Story sample
<img width="1581" alt="InteractionDesigner___Toolbar_-_With_Grouped_Buttons_Slot_⋅_Storybook" src="https://user-images.githubusercontent.com/68745918/95626337-4f9b7800-0a37-11eb-9425-382d3d4ebf5a.png">
