### PR TITLE
VMO-3432 fix-type-c-does-not-satisfy-the-constraint

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     "tests/**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests/**/storybook.spec.ts"
   ]
 }


### PR DESCRIPTION
It was a ts issue on storybook. I'm wondering why we didn't have it before?
My proposal is just to exclude storybook from `tsconfig.json`