### PR TITLE
VMO-3746 [Viamo Blocks] Add #extends slot to Community Flow Builder blocks

### DIFF
--- a/src/components/interaction-designer/block-types/ConsoleIO_PrintBlock.vue
+++ b/src/components/interaction-designer/block-types/ConsoleIO_PrintBlock.vue
@@ -14,6 +14,7 @@
                        :block="block"
                        :flow="flow" />
 
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/ConsoleIO_ReadBlock.vue
+++ b/src/components/interaction-designer/block-types/ConsoleIO_ReadBlock.vue
@@ -20,7 +20,7 @@
             @keydown="filterVariableName"
             @input="updatedestinationVariables($event, i)"/>
       </div>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/Core_CaseBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_CaseBlock.vue
@@ -16,7 +16,7 @@
             :expression-identifier="exit.uuid"
             @commitExpressionChange="editCaseBlockExit"/>
       </div>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/Core_LogBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_LogBlock.vue
@@ -30,7 +30,7 @@
           </template>
         </template>
       </div>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/Core_OutputBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_OutputBlock.vue
@@ -13,7 +13,7 @@
           :placeholder="'flow-builder.edit-expression' | trans"
           :current-expression="value"
           @commitExpressionChange="commitExpressionChange"/>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/Core_RunFlowBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_RunFlowBlock.vue
@@ -21,7 +21,7 @@
           </option>
         </select>
       </div>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/Core_SetContactPropertyBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_SetContactPropertyBlock.vue
@@ -15,7 +15,7 @@
                          :placeholder="'flow-builder.edit-expression' | trans"
                          :current-expression="propertyValue"
                          @commitExpressionChange="commitExpressionChange"/>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
         :flow="flow"
         :block-id="block.uuid"/>

--- a/src/components/interaction-designer/block-types/Core_SetGroupMembershipBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_SetGroupMembershipBlock.vue
@@ -23,7 +23,7 @@
       </div>
 
       <group-selector :block="block"/>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
         :flow="flow"
         :block-id="block.uuid"/>

--- a/src/components/interaction-designer/block-types/MobilePrimitives_MessageBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_MessageBlock.vue
@@ -12,6 +12,7 @@
                        :resource="promptResource"
                        :block="block"
                        :flow="flow" />
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/MobilePrimitives_NumericResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_NumericResponseBlock.vue
@@ -18,7 +18,7 @@
                        :resource="promptResource"
                        :block="block"
                        :flow="flow" />
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/MobilePrimitives_OpenResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_OpenResponseBlock.vue
@@ -16,7 +16,7 @@
                        :resource="promptResource"
                        :block="block"
                        :flow="flow" />
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/MobilePrimitives_SelectManyResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_SelectManyResponseBlock.vue
@@ -50,7 +50,7 @@
                          :block="block"
                          :flow="flow" />
       </div>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/MobilePrimitives_SelectOneResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_SelectOneResponseBlock.vue
@@ -52,7 +52,7 @@
                          :block="block"
                          :flow="flow" />
       </div>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/SmartDevices_LocationResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/SmartDevices_LocationResponseBlock.vue
@@ -11,7 +11,7 @@
 
       <block-threshold-editor :block="block" @commitAccuracyThresholdMetersChange="updateThreshold"/>
       <block-timeout-editor :block="block" @commitAccuracyTimeoutSecondsChange="updateTimeout"/>
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
@@ -7,7 +7,7 @@
       <block-name-editor :block="block" />
       <block-label-editor :block="block" />
       <block-semantic-label-editor :block="block" />
-
+      <slot name="extras"></slot>
       <first-block-editor-button
           :flow="flow"
           :block-id="block.uuid" />

--- a/src/views/InteractionDesigner.vue
+++ b/src/views/InteractionDesigner.vue
@@ -8,13 +8,11 @@
         <div class="tree-sidebar-edit-block"
              :data-block-type="activeBlock && activeBlock.type"
              :data-for-block-id="activeBlock && activeBlock.uuid">
-
-          <div v-if="activeBlock"
-               :is="`Flow${activeBlock.type.replace(/\\/g, '')}`"
-               :block="activeBlock"
-               :flow="activeFlow"
-          />
-
+          <component v-if="activeBlock"
+                     :is="`Flow${activeBlock.type.replace(/\\/g, '')}`"
+                     :block="activeBlock"
+                     :flow="activeFlow">
+          </component>
         </div>
 
 <!--        <tree-editor v-if="sidebarType === 'TreeEditor'"-->


### PR DESCRIPTION
Added extras slot above the options section which shows the set first block button. The screenshot shows some test label and input field that I added(but removed in this PR).

![image](https://user-images.githubusercontent.com/23651142/114772256-727a5200-9d22-11eb-8f59-aabb357e82a6.png)
