### PR TITLE
VMO-3120 - fix flow lifecycle

### DIFF
--- a/src/views/InteractionDesigner.vue
+++ b/src/views/InteractionDesigner.vue
@@ -199,8 +199,8 @@ export default {
     if (!this.activeFlow) {
       this.flow_setActiveFlowId({ flowId: null })
       this.$router.replace(
-        this.route('flows.fetchFlow', { flowId: this.id }),
-        { query: { nextUrl: this.$route.path } },
+        { path: this.route('flows.fetchFlow', { flowId: this.id }), 
+          query: { nextUrl: this.$route.path } },
       )
     }
 


### PR DESCRIPTION
The second argument for router.replace is onload. To use a query param it should be done like this. I'm 100% I tested this multiple times during the flow lifecycle work so I don't really understand how this became broken but this fixes it!