### PR TITLE
Vmo 4212 block toolbar on hover

### DIFF
--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -17,7 +17,7 @@
       @dragStarted="selectBlock"
       @dragEnded="handleDraggableEndedForBlock"
       @destroyed="handleDraggableDestroyedForBlock">
-      <div class="d-flex justify-content-between" v-if="showToolbar">
+      <div class="d-flex justify-content-between" v-if="isBlockSelected || showToolbar">
         <div class="header-actions-left">
           <!--Selection-->
           <font-awesome-icon

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -1,5 +1,7 @@
 <template>
-  <div @click="selectBlock">
+  <div @click="selectBlock"
+       @mouseover="showToolbar = true"
+       @mouseleave="showToolbar = false">
     <plain-draggable
       v-if="hasLayout"
       ref="draggable"
@@ -15,7 +17,7 @@
       @dragStarted="selectBlock"
       @dragEnded="handleDraggableEndedForBlock"
       @destroyed="handleDraggableDestroyedForBlock">
-      <div class="d-flex justify-content-between">
+      <div class="d-flex justify-content-between" v-if="showToolbar">
         <div class="header-actions-left">
           <!--Selection-->
           <font-awesome-icon
@@ -233,6 +235,7 @@ export default {
   data() {
     return {
       isDeleting: false,
+      showToolbar: false,
       livePosition: null,
       labelContainerMaxWidth: LABEL_CONTAINER_MAX_WIDTH,
     }

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -629,8 +629,8 @@ export default {
     opacity: 0; // default state of hidden
 
     margin-top: -39.75px;
-    margin-right: -8px;
-    margin-left: -8px;
+    margin-right: -7px;
+    margin-left: -7px;
     padding: 8px;
 
     border-top: inherit;
@@ -738,6 +738,7 @@ export default {
     opacity: 1;
   }
 
+  // block exit states
   &.active,
   &:hover {
     .block-exit .block-exit-remove {
@@ -745,10 +746,18 @@ export default {
     }
   }
 
+  // toolbar states
   &.has-toolbar,
   &:hover {
     .block-toolbar {
       opacity: 1;
+    }
+  }
+
+  &.active {
+    .block-toolbar {
+      margin-left: -8px;
+      margin-right: -8px;
     }
   }
 }

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -1,13 +1,12 @@
 <template>
-  <div @click="selectBlock"
-       @mouseover="showToolbar = true"
-       @mouseleave="showToolbar = false">
+  <div @click="selectBlock">
     <plain-draggable
       v-if="hasLayout"
       ref="draggable"
       class="block"
       :class="{
         active: isBlockActivated,
+        'has-toolbar': isBlockSelected,
         [`category-${blockClasses[block.type].category}`]: true,
       }"
       :start-x="x"
@@ -17,7 +16,7 @@
       @dragStarted="selectBlock"
       @dragEnded="handleDraggableEndedForBlock"
       @destroyed="handleDraggableDestroyedForBlock">
-      <div class="d-flex justify-content-between" v-if="isBlockSelected || showToolbar">
+      <div class="block-toolbar d-flex justify-content-between">
         <div class="header-actions-left">
           <!--Selection-->
           <font-awesome-icon
@@ -235,7 +234,6 @@ export default {
   data() {
     return {
       isDeleting: false,
-      showToolbar: false,
       livePosition: null,
       labelContainerMaxWidth: LABEL_CONTAINER_MAX_WIDTH,
     }
@@ -625,6 +623,23 @@ export default {
   transition: opacity 200ms ease-in-out,
   background-color 200ms ease-in-out;
 
+  .block-toolbar {
+    transition: opacity 200ms ease-in-out;
+    background: white;
+    opacity: 0; // default state of hidden
+
+    margin-top: -39.75px;
+    margin-right: -8px;
+    margin-left: -8px;
+    padding: 8px;
+
+    border-top: inherit;
+    border-right: inherit;
+    border-left: inherit;
+    border-top-right-radius: inherit;
+    border-top-left-radius: inherit;
+  }
+
   .block-label {
     font-size: 14px;
     font-weight: normal;
@@ -726,6 +741,13 @@ export default {
   &.active,
   &:hover {
     .block-exit .block-exit-remove {
+      opacity: 1;
+    }
+  }
+
+  &.has-toolbar,
+  &:hover {
+    .block-toolbar {
       opacity: 1;
     }
   }

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -624,7 +624,7 @@ export default {
   background-color 200ms ease-in-out;
 
   .block-toolbar {
-    transition: opacity 200ms ease-in-out;
+    transition: opacity 100ms ease-in-out;
     background: white;
     opacity: 0; // default state of hidden
 


### PR DESCRIPTION
@poojahpatil90 @safydy Do you think this is a fair solution? I simply background:white + fade-in toolbar right over top of the block. I've inherited borders to make it easier to match up if we adjust styling in the future.