### PR TITLE
Vmo 4323 fix overlapping blocks

### DIFF
--- a/src/components/interaction-designer/BuilderCanvas.vue
+++ b/src/components/interaction-designer/BuilderCanvas.vue
@@ -139,11 +139,11 @@ export default class BuilderCanvas extends Vue {
   }
 
   get blockAtTheLowestPosition(): any {
-    return maxBy(this.activeFlow.blocks, 'block.ui_metadata.canvas_coordinates.y')
+    return maxBy(this.activeFlow.blocks, 'ui_metadata.canvas_coordinates.y')
   }
 
   get blockAtTheFurthestRightPosition(): any {
-    return maxBy(this.activeFlow.blocks, 'block.ui_metadata.canvas_coordinates.x')
+    return maxBy(this.activeFlow.blocks, 'ui_metadata.canvas_coordinates.x')
   }
 
   get windowHeight(): number {
@@ -155,7 +155,7 @@ export default class BuilderCanvas extends Vue {
   }
 
   get canvasHeight(): any {
-    if (this.activeFlow.blocks.length == 0) {
+    if (this.activeFlow.blocks.length === 0) {
       return this.windowHeight
     }
 
@@ -164,7 +164,7 @@ export default class BuilderCanvas extends Vue {
       return this.windowHeight
     }
 
-    const yPosition = get(this.blockAtTheLowestPosition, 'block.ui_metadata.canvas_coordinates.y')
+    const yPosition: number = this.blockAtTheLowestPosition.ui_metadata.canvas_coordinates.y
     const scrollHeight = yPosition + this.blockHeight + MARGIN_HEIGHT
 
     if (scrollHeight < this.windowHeight) {
@@ -175,7 +175,7 @@ export default class BuilderCanvas extends Vue {
   }
 
   get canvasWidth(): number {
-    if (this.activeFlow.blocks.length == 0) {
+    if (this.activeFlow.blocks.length === 0) {
       return this.windowWidth - this.widthAdjustment
     }
 
@@ -184,7 +184,7 @@ export default class BuilderCanvas extends Vue {
       return this.windowWidth - this.widthAdjustment
     }
 
-    const xPosition = get(this.blockAtTheLowestPosition, 'block.ui_metadata.canvas_coordinates.x')
+    const xPosition: number = this.blockAtTheLowestPosition.ui_metadata.canvas_coordinates.x
     const scrollWidth = xPosition + this.blockWidth + MARGIN_WIDTH
 
     if (scrollWidth < this.windowWidth) {

--- a/src/components/interaction-designer/Connection.vue
+++ b/src/components/interaction-designer/Connection.vue
@@ -101,13 +101,13 @@ export default {
       // generate drafts while 'between exits' or 'source/destination unknown'
       // todo: push these out into ?block?
       const source = this.source || {
-        ...set({}, 'block.ui_metadata.canvas_coordinates.x', this.position.x),
-        ...set({}, 'block.ui_metadata.canvas_coordinates.y', this.position.y),
+        ...set({}, 'ui_metadata.canvas_coordinates.x', this.position.x),
+        ...set({}, 'ui_metadata.canvas_coordinates.y', this.position.y),
       }
 
       const target = this.target || {
-        ...set({}, 'block.ui_metadata.canvas_coordinates.x', this.position.x),
-        ...set({}, 'block.ui_metadata.canvas_coordinates.y', this.position.y),
+        ...set({}, 'ui_metadata.canvas_coordinates.x', this.position.x),
+        ...set({}, 'ui_metadata.canvas_coordinates.y', this.position.y),
       }
 
       return this.repaintCacheKeyGenerator(source, target)

--- a/src/store/builder/index.ts
+++ b/src/store/builder/index.ts
@@ -377,13 +377,12 @@ export function generateConnectionLayoutKeyFor(source: IBlock, target: IBlock) {
 }
 
 export function computeBlockUiData(block?: IBlock | null) {
-  const xDelta = 160
-  const yDelta = 180
+  const xDelta = 120
+  const yDelta = 110
+  let xPosition = block ? block.ui_metadata.canvas_coordinates.x : null
+  let yPosition = block ? block.ui_metadata.canvas_coordinates.y : null
 
-  let xPosition = get(block, 'block.ui_metadata.canvas_coordinates.x')
-  let yPosition = get(block, 'block.ui_metadata.canvas_coordinates.y')
-
-  if (!xPosition || !yPosition) {
+  if (xPosition === null || yPosition === null) {
     const viewPortCenter = getViewportCenter()
     xPosition = viewPortCenter.x
     yPosition = viewPortCenter.y
@@ -394,6 +393,7 @@ export function computeBlockUiData(block?: IBlock | null) {
     y: yPosition + yDelta,
   }
 }
+
 export function computeBlockVendorUiData(block?: IBlock | null) {
   return {
     isSelected: false,

--- a/src/store/builder/index.ts
+++ b/src/store/builder/index.ts
@@ -361,8 +361,8 @@ export function generateConnectionLayoutKeyFor(source: IBlock, target: IBlock) {
   console.debug('store/builder', 'generateConnectionLayoutKeyFor', source.uuid, target.uuid)
   return [
     // coords
-    [get(source, 'block.ui_metadata.canvas_coordinates.x'), get(source, 'block.ui_metadata.canvas_coordinates.y')],
-    [get(target, 'block.ui_metadata.canvas_coordinates.x'), get(target, 'block.ui_metadata.canvas_coordinates.y')],
+    [source.ui_metadata.canvas_coordinates.x, source.ui_metadata.canvas_coordinates.y],
+    [target.ui_metadata.canvas_coordinates.x, target.ui_metadata.canvas_coordinates.y],
 
     // block titles
     source.label,
@@ -371,8 +371,8 @@ export function generateConnectionLayoutKeyFor(source: IBlock, target: IBlock) {
     // todo: this needs to be a computed prop // possibly on store as getter by blockId ?
 
     // other exit titles
-    ...map(source.exits, 'tag'),
-    ...map(target.exits, 'tag'),
+    ...map(source.exits, 'name'),
+    ...map(target.exits, 'name'),
   ]
 }
 


### PR DESCRIPTION
The pbm was we put `block.ui_metadata...` rather than `ui_metadata...` in `lodash.get` path. I took the opportunity to remove the usage of `get()` in some part of the code.

Screenshots
<img width="518" alt="Screen Shot 2021-07-21 at 3 02 17 PM" src="https://user-images.githubusercontent.com/68745918/126561949-fe848380-378d-4a7b-9df3-5dcef1c31ea5.png">
