### PR TITLE
Vmo 4149 unified block photo response

### DIFF
--- a/src/assets/messages.json
+++ b/src/assets/messages.json
@@ -1,5 +1,7 @@
 {
   "en.flow-builder": {
+    "photo-response-prompt": "Photo response prompt",
+    "include-photo-response-prompt": "Include photo response prompt",
     "group-membership-action-hint": "This action allows you to add the contact to a group, by adding a group value and expression",
     "set-group-membership": "Add to group ",
     "clear-group-membership": "Remove from group",
@@ -1623,6 +1625,8 @@
     "simulator-unsupported-block": "block is not supported right now. You will not be able to proceed. Please Exit."
   },
   "fr.flow-builder": {
+    "photo-response-prompt": "Invite de réponse photo",
+    "include-photo-response-prompt": "Inclure une invite de réponse photo",
     "group-membership-action-hint": "Cette action vous permet d'ajouter le contact à un groupe, en ajoutant une valeur et une expression de groupe",
     "set-group-membership": "Ajouter au groupe",
     "clear-group-membership": "Supprimer du groupe",

--- a/src/components/interaction-designer/block-editors/PhotoPromptEditor.vue
+++ b/src/components/interaction-designer/block-editors/PhotoPromptEditor.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="photo-prompt-editor">
+    <label class="text-primary">{{ 'flow-builder.photo-response-prompt' | trans }}</label>
+    <div class="custom-control custom-checkbox">
+      <input
+        id="shouldIncludePrompt"
+        :value="shouldSetContactProperty"
+        :checked="shouldSetContactProperty"
+        type="checkbox"
+        name="includePrompt"
+        class="custom-control-input"
+        @change="toggleIncludePrompt">
+      <label
+        class="custom-control-label font-weight-normal"
+        for="shouldIncludePrompt">
+        {{ 'flow-builder.include-photo-response-prompt' | trans }}
+      </label>
+    </div>
+    <resource-editor
+      v-if="promptResource"
+      :resource="promptResource"
+      :block="block"
+      :flow="flow" />
+  </div>
+</template>
+
+<script lang="ts">
+import {Component, Prop} from 'vue-property-decorator'
+import {mixins} from 'vue-class-component'
+import Lang from '@/lib/filters/lang'
+import {IBlock, IFlow, IResource} from '@floip/flow-runner'
+import {namespace} from 'vuex-class'
+import ResourceEditor from '../resource-editors/ResourceEditor.vue'
+
+const flowVuexNamespace = namespace('flow')
+
+@Component({
+  components: {
+    ResourceEditor,
+  },
+})
+class LabelEditor extends mixins(Lang) {
+  @Prop() readonly block!: IBlock
+  @Prop() readonly flow!: IFlow
+
+  shouldSetContactProperty = false
+
+  created(): void {
+    this.shouldSetContactProperty = this.block.config.prompt !== ''
+  }
+
+  async toggleIncludePrompt(): Promise<void> {
+    this.shouldSetContactProperty = !this.shouldSetContactProperty
+    if (!this.shouldSetContactProperty) {
+      this.resource_delete({
+        resourceId: this.block.config.prompt,
+      })
+      this.block.config.prompt = ''
+    } else {
+      const blankMessageResource = await this.flow_addBlankResourceForEnabledModesAndLangs()
+      this.block_updateConfigByPath({
+        blockId: this.block.uuid,
+        path: 'prompt',
+        value: blankMessageResource.uuid,
+      })
+    }
+  }
+
+  get promptResource(): IResource {
+    return this.resourcesByUuid[this.block.config.prompt]
+  }
+
+  @flowVuexNamespace.Getter resourcesByUuid!: { [key: string]: IResource }
+
+  @flowVuexNamespace.Action flow_addBlankResourceForEnabledModesAndLangs!: () => Promise<IResource>
+
+  @flowVuexNamespace.Mutation resource_delete!: ({resourceId}: { resourceId: string }) => void
+
+  @flowVuexNamespace.Mutation block_updateConfigByPath!: (
+    {blockId, path, value}: { blockId: string, path: string, value: string | object }
+  ) => void
+}
+export default LabelEditor
+</script>

--- a/src/components/interaction-designer/block-editors/PhotoPromptEditor.vue
+++ b/src/components/interaction-designer/block-editors/PhotoPromptEditor.vue
@@ -4,8 +4,8 @@
     <div class="custom-control custom-checkbox">
       <input
         id="shouldIncludePrompt"
-        :value="shouldSetContactProperty"
-        :checked="shouldSetContactProperty"
+        :value="shouldIncludePrompt"
+        :checked="shouldIncludePrompt"
         type="checkbox"
         name="includePrompt"
         class="custom-control-input"
@@ -43,15 +43,15 @@ class LabelEditor extends mixins(Lang) {
   @Prop() readonly block!: IBlock
   @Prop() readonly flow!: IFlow
 
-  shouldSetContactProperty = false
+  shouldIncludePrompt = false
 
   created(): void {
-    this.shouldSetContactProperty = this.block.config.prompt !== ''
+    this.shouldIncludePrompt = this.block.config.prompt !== ''
   }
 
   async toggleIncludePrompt(): Promise<void> {
-    this.shouldSetContactProperty = !this.shouldSetContactProperty
-    if (!this.shouldSetContactProperty) {
+    this.shouldIncludePrompt = !this.shouldIncludePrompt
+    if (!this.shouldIncludePrompt) {
       this.resource_delete({
         resourceId: this.block.config.prompt,
       })

--- a/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
@@ -12,6 +12,11 @@
         :block="block" />
       <block-name-editor :block="block" />
 
+      <hr>
+      <block-output-branching-config
+        :block="block"
+        :has-exit-per-choice="false" />
+
       <slot name="extras" />
 
       <categorization :block="block" />
@@ -35,7 +40,7 @@ import {namespace} from 'vuex-class'
 import {Component, Prop} from 'vue-property-decorator'
 // import IPhotoResponseBlock from '@floip/flow-runner/src/model/block/IPhotoResponseBlock' // TODO: to be created in flow-runner
 import {IBlock, IFlow, IResource} from '@floip/flow-runner'
-
+import BlockOutputBranchingConfig from '@/components/interaction-designer/block-editors/BlockOutputBranchingConfig.vue'
 import PhotoStore, {BLOCK_TYPE} from '@/store/flow/block-types/SmartDevices_PhotoResponseBlockStore'
 import Lang from '@/lib/filters/lang'
 import Categorization from '@/components/interaction-designer/block-editors/Categorization.vue'
@@ -60,6 +65,7 @@ const builderVuexNamespace = namespace('builder')
     FirstBlockEditorButton,
     BlockId,
     Categorization,
+    BlockOutputBranchingConfig,
   },
 })
 class SmartDevices_PhotoResponseBlock extends mixins(Lang) {

--- a/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
@@ -12,11 +12,7 @@
         :block="block" />
       <block-name-editor :block="block" />
 
-      <resource-editor
-        v-if="promptResource"
-        :resource="promptResource"
-        :block="block"
-        :flow="flow" />
+      <photo-prompt-editor :block="block" :flow="flow" />
 
       <hr>
       <block-output-branching-config
@@ -58,7 +54,7 @@ import BlockLabelEditor from '../block-editors/LabelEditor.vue'
 import BlockSemanticLabelEditor from '../block-editors/SemanticLabelEditor.vue'
 import FirstBlockEditorButton from '../flow-editors/FirstBlockEditorButton.vue'
 import BlockId from '../block-editors/BlockId.vue'
-import ResourceEditor from '../resource-editors/ResourceEditor.vue'
+import PhotoPromptEditor from '../block-editors/PhotoPromptEditor.vue'
 
 const flowVuexNamespace = namespace('flow')
 const builderVuexNamespace = namespace('builder')
@@ -73,7 +69,7 @@ const builderVuexNamespace = namespace('builder')
     BlockId,
     Categorization,
     BlockOutputBranchingConfig,
-    ResourceEditor,
+    PhotoPromptEditor,
   },
 })
 class SmartDevices_PhotoResponseBlock extends mixins(Lang) {
@@ -83,12 +79,6 @@ class SmartDevices_PhotoResponseBlock extends mixins(Lang) {
   @Prop() readonly flow!: IFlow
 
   showSemanticLabel = false
-
-  get promptResource(): IResource {
-    return this.resourcesByUuid[this.block.config.prompt]
-  }
-
-  @flowVuexNamespace.Getter resourcesByUuid!: { [key: string]: IResource }
 
   @builderVuexNamespace.Getter isEditable !: boolean
 }

--- a/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
@@ -12,6 +12,12 @@
         :block="block" />
       <block-name-editor :block="block" />
 
+      <resource-editor
+        v-if="promptResource"
+        :resource="promptResource"
+        :block="block"
+        :flow="flow" />
+
       <hr>
       <block-output-branching-config
         :block="block"
@@ -52,6 +58,7 @@ import BlockLabelEditor from '../block-editors/LabelEditor.vue'
 import BlockSemanticLabelEditor from '../block-editors/SemanticLabelEditor.vue'
 import FirstBlockEditorButton from '../flow-editors/FirstBlockEditorButton.vue'
 import BlockId from '../block-editors/BlockId.vue'
+import ResourceEditor from '../resource-editors/ResourceEditor.vue'
 
 const flowVuexNamespace = namespace('flow')
 const builderVuexNamespace = namespace('builder')
@@ -66,6 +73,7 @@ const builderVuexNamespace = namespace('builder')
     BlockId,
     Categorization,
     BlockOutputBranchingConfig,
+    ResourceEditor,
   },
 })
 class SmartDevices_PhotoResponseBlock extends mixins(Lang) {
@@ -75,6 +83,10 @@ class SmartDevices_PhotoResponseBlock extends mixins(Lang) {
   @Prop() readonly flow!: IFlow
 
   showSemanticLabel = false
+
+  get promptResource(): IResource {
+    return this.resourcesByUuid[this.block.config.prompt]
+  }
 
   @flowVuexNamespace.Getter resourcesByUuid!: { [key: string]: IResource }
 

--- a/src/store/flow/block-types/SmartDevices_PhotoResponseBlockStore.ts
+++ b/src/store/flow/block-types/SmartDevices_PhotoResponseBlockStore.ts
@@ -14,6 +14,8 @@ export const mutations: MutationTree<IFlowsState> = {}
 
 export const actions: ActionTree<IFlowsState, IRootState> = {
   async createWith({dispatch}, {props}: { props: { uuid: string } & Partial<IBlock> }) {
+    const blankMessageResource = await dispatch('flow/flow_addBlankResourceForEnabledModesAndLangs', null, {root: true})
+
     const exits: IBlockExit[] = [
       await dispatch('flow/block_createBlockDefaultExitWith', {
         props: ({
@@ -35,7 +37,9 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
       label: '',
       semantic_label: '',
       exits,
-      config: {},
+      config: {
+        prompt: blankMessageResource.uuid,
+      },
       tags: [],
     })
   },

--- a/src/store/flow/block-types/SmartDevices_PhotoResponseBlockStore.ts
+++ b/src/store/flow/block-types/SmartDevices_PhotoResponseBlockStore.ts
@@ -14,8 +14,6 @@ export const mutations: MutationTree<IFlowsState> = {}
 
 export const actions: ActionTree<IFlowsState, IRootState> = {
   async createWith({dispatch}, {props}: { props: { uuid: string } & Partial<IBlock> }) {
-    const blankMessageResource = await dispatch('flow/flow_addBlankResourceForEnabledModesAndLangs', null, {root: true})
-
     const exits: IBlockExit[] = [
       await dispatch('flow/block_createBlockDefaultExitWith', {
         props: ({
@@ -38,7 +36,7 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
       semantic_label: '',
       exits,
       config: {
-        prompt: blankMessageResource.uuid,
+        prompt: '', // will add resource if the user want it from the UI config
       },
       tags: [],
     })

--- a/tests/unit/__snapshots__/storybook.spec.ts.snap
+++ b/tests/unit/__snapshots__/storybook.spec.ts.snap
@@ -2828,6 +2828,135 @@ exports[`Storyshots SmartDevices/Photo Response Block Non Starting Block 1`] = `
                               </small>
                             </div>
                           </div>
+                           
+                          <div
+                            class="photo-prompt-editor"
+                          >
+                            <label
+                              class="text-primary"
+                            >
+                              Photo response prompt
+                            </label>
+                             
+                            <div
+                              class="custom-control custom-checkbox"
+                            >
+                              <input
+                                class="custom-control-input"
+                                id="shouldIncludePrompt"
+                                name="includePrompt"
+                                type="checkbox"
+                                value="false"
+                              />
+                               
+                              <label
+                                class="custom-control-label font-weight-normal"
+                                for="shouldIncludePrompt"
+                              >
+                                
+      Include photo response prompt
+    
+                              </label>
+                            </div>
+                             
+                            <!---->
+                          </div>
+                           
+                          <hr />
+                           
+                          <div
+                            class="block-output-branching-config"
+                          >
+                            <div
+                              class="form-group"
+                            >
+                              <label
+                                class="text-primary"
+                              >
+                                Output Branching
+                              </label>
+                               
+                              <div
+                                class="btn-group d-block"
+                              >
+                                <!---->
+                                 
+                                <button
+                                  class="btn btn-sm btn-outline-primary"
+                                  data-placement="bottom"
+                                  data-toggle="tooltip"
+                                  title="One output for all choices"
+                                >
+                                  <font-awesome-icon
+                                    class="exit-type-icons"
+                                    icon="fac,single-exit"
+                                  />
+                                </button>
+                                 
+                                <button
+                                  class="btn btn-sm btn-outline-primary"
+                                  data-placement="bottom"
+                                  data-toggle="tooltip"
+                                  title="flow-builder.advanced-configuration-of-outputs"
+                                >
+                                  <font-awesome-icon
+                                    class="exit-type-icons"
+                                    icon="fac,advanced-exit"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                             
+                            <!---->
+                             
+                            <div
+                              class="form-group"
+                            >
+                              <h6>
+                                When no valid response/all exit expressions evaluate to false
+                              </h6>
+                               
+                              <div
+                                class="form-check"
+                              >
+                                <input
+                                  class="form-check-input"
+                                  id="END_CALL"
+                                  type="radio"
+                                  value="END_CALL"
+                                />
+                                 
+                                <label
+                                  class="form-check-label"
+                                  for="END_CALL"
+                                >
+                                  
+        End the call/session
+      
+                                </label>
+                              </div>
+                               
+                              <div
+                                class="form-check"
+                              >
+                                <input
+                                  class="form-check-input"
+                                  id="CONTINUE_THRU_EXIT"
+                                  type="radio"
+                                  value="CONTINUE_THRU_EXIT"
+                                />
+                                 
+                                <label
+                                  class="form-check-label"
+                                  for="CONTINUE_THRU_EXIT"
+                                >
+                                  
+        Continue through Default exit
+      
+                                </label>
+                              </div>
+                            </div>
+                          </div>
                             
                           <div
                             class="block-categorization"


### PR DESCRIPTION
**Note**:
- setting exit.value when having Single exit mode will be done in vmo-4322
- in master, we already have setContactProp & Categorization

About `prompt` implementation, I had this [thread](https://votomobile.slack.com/archives/CGGFKUP4Y/p1627083068197500) on squad2 channel to confirm it should be localized

Screenshots
<img width="622" alt="Screen Shot 2021-07-23 at 7 46 25 PM" src="https://user-images.githubusercontent.com/68745918/126854486-c98a17cf-a403-4c5f-b00c-53bdd3d6da51.png">

<img width="625" alt="Screen Shot 2021-07-23 at 7 47 12 PM" src="https://user-images.githubusercontent.com/68745918/126854488-08478267-40c6-43fe-9adf-23ebedcfbebc.png">
