### PR TITLE
VMO-4346 - fix exit becoming invalid value on create without target

### DIFF
--- a/src/store/builder/5b8c87d6-de90-4bc4-8668-4f040000006e-valid-flow.json
+++ b/src/store/builder/5b8c87d6-de90-4bc4-8668-4f040000006e-valid-flow.json
@@ -54,10 +54,7 @@
             }
           ],
           "config": {
-            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124",
-            "set_contact_property": {
-              "property_value": "@block.value"
-            }
+            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124"
           }
         },
         {
@@ -101,9 +98,6 @@
             "validation_maximum": 0,
             "ivr": {
               "max_digits": -1
-            },
-            "set_contact_property": {
-              "property_value": "@block.value"
             }
           }
         }

--- a/src/store/builder/5b8c87d6-de90-4bc4-8668-4f040000006e-valid-flow.json
+++ b/src/store/builder/5b8c87d6-de90-4bc4-8668-4f040000006e-valid-flow.json
@@ -1,8 +1,8 @@
 {
   "specification_version": "1.0.0-rc2",
   "uuid": "3666a05d-3792-482b-8f7f-9e2472e4f027",
-  "name": "container name",
-  "description": "container description",
+  "name": "TODO",
+  "description": "TODO",
   "vendor_metadata": {},
   "flows": [
     {
@@ -27,7 +27,12 @@
       "blocks": [
         {
           "uuid": "eb34ac1f-f27c-43f4-87c9-7f61309bc725",
-          "ui_metadata": {"canvas_coordinates": {"x": 164, "y": 197}},
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 164,
+              "y": 197
+            }
+          },
           "vendor_metadata": {
             "io_viamo": {
               "uiData": {
@@ -49,18 +54,28 @@
             }
           ],
           "config": {
-            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124"
+            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124",
+            "set_contact_property": {
+              "property_value": "@block.value"
+            }
           }
         },
         {
           "uuid": "a5d6f811-7ba6-404d-890f-29d6c10e43b5",
-          "ui_metadata": {"canvas_coordinates": {"x": 380, "y": 227}},
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 380,
+              "y": 227
+            }
+          },
           "vendor_metadata": {
             "io_viamo": {
               "uiData": {
                 "xPosition": 380,
                 "yPosition": 227
-              }
+              },
+              "branchingType": "UNIFIED",
+              "noValidResponse": "END_CALL"
             }
           },
           "type": "MobilePrimitives.NumericResponse",
@@ -69,9 +84,9 @@
           "semantic_label": "",
           "exits": [
             {
-              "uuid": "0638e873-a28c-4b7d-9578-5341de4e66bf",
-              "name": "Default",
-              "default": true,
+              "uuid": "d284c5b3-07b8-4d64-b928-702e0df4394d",
+              "name": "1",
+              "test": "true",
               "config": {}
             },
             {
@@ -86,6 +101,9 @@
             "validation_maximum": 0,
             "ivr": {
               "max_digits": -1
+            },
+            "set_contact_property": {
+              "property_value": "@block.value"
             }
           }
         }

--- a/src/store/builder/f0492216-65f3-4dc7-a1d8-8f79d1d30c11-flow.json
+++ b/src/store/builder/f0492216-65f3-4dc7-a1d8-8f79d1d30c11-flow.json
@@ -54,10 +54,7 @@
             }
           ],
           "config": {
-            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124",
-            "set_contact_property": {
-              "property_value": "@block.value"
-            }
+            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124"
           }
         },
         {
@@ -101,9 +98,6 @@
             "validation_maximum": 0,
             "ivr": {
               "max_digits": -1
-            },
-            "set_contact_property": {
-              "property_value": "@block.value"
             }
           }
         }

--- a/src/store/builder/f0492216-65f3-4dc7-a1d8-8f79d1d30c11-flow.json
+++ b/src/store/builder/f0492216-65f3-4dc7-a1d8-8f79d1d30c11-flow.json
@@ -1,8 +1,8 @@
 {
   "specification_version": "1.0.0-rc2",
   "uuid": "3666a05d-3792-482b-8f7f-9e2472e4f027",
-  "name": "container name",
-  "description": "container description",
+  "name": "TODO",
+  "description": "TODO",
   "vendor_metadata": {},
   "flows": [
     {
@@ -27,7 +27,12 @@
       "blocks": [
         {
           "uuid": "eb34ac1f-f27c-43f4-87c9-7f61309bc725",
-          "ui_metadata": {"canvas_coordinates": {"x": 164, "y": 197}},
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 164,
+              "y": 197
+            }
+          },
           "vendor_metadata": {
             "io_viamo": {
               "uiData": {
@@ -49,18 +54,28 @@
             }
           ],
           "config": {
-            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124"
+            "message": "3087a849-3f88-4fe4-8992-a8f5a8866124",
+            "set_contact_property": {
+              "property_value": "@block.value"
+            }
           }
         },
         {
           "uuid": "a5d6f811-7ba6-404d-890f-29d6c10e43b5",
-          "ui_metadata": {"canvas_coordinates": {"x": 380, "y": 227}},
+          "ui_metadata": {
+            "canvas_coordinates": {
+              "x": 380,
+              "y": 227
+            }
+          },
           "vendor_metadata": {
             "io_viamo": {
               "uiData": {
                 "xPosition": 380,
                 "yPosition": 227
-              }
+              },
+              "branchingType": "UNIFIED",
+              "noValidResponse": "END_CALL"
             }
           },
           "type": "MobilePrimitives.NumericResponse",
@@ -69,9 +84,9 @@
           "semantic_label": "",
           "exits": [
             {
-              "uuid": "0638e873-a28c-4b7d-9578-5341de4e66bf",
-              "name": "Default",
-              "default": true,
+              "uuid": "d284c5b3-07b8-4d64-b928-702e0df4394d",
+              "name": "1",
+              "test": "true",
               "config": {}
             },
             {
@@ -86,6 +101,9 @@
             "validation_maximum": 0,
             "ivr": {
               "max_digits": -1
+            },
+            "set_contact_property": {
+              "property_value": "@block.value"
             }
           }
         }

--- a/src/store/flow/block.ts
+++ b/src/store/flow/block.ts
@@ -98,6 +98,9 @@ export const mutations: MutationTree<IFlowsState> = {
     )
   },
   block_setBlockExitDestinationBlockId(state, {blockId, exitId, destinationBlockId}) {
+    if(!destinationBlockId) {
+      destinationBlockId = undefined
+    }
     const block = findBlockOnActiveFlowWith(blockId, state as unknown as IContext)
     findBlockExitWith(exitId, block)
       .destination_block = destinationBlockId

--- a/src/store/flow/block.ts
+++ b/src/store/flow/block.ts
@@ -98,7 +98,7 @@ export const mutations: MutationTree<IFlowsState> = {
     )
   },
   block_setBlockExitDestinationBlockId(state, {blockId, exitId, destinationBlockId}) {
-    if(!destinationBlockId) {
+    if (!destinationBlockId) {
       destinationBlockId = undefined
     }
     const block = findBlockOnActiveFlowWith(blockId, state as unknown as IContext)


### PR DESCRIPTION
Setting to null when you don't finish connecting a block is invalid - unset completely.

Update some example flows as currently the config for these test flows is missing some important exit defaults we have added recently. Without these if you play with exits without viewing the block sidebar first then things can behave strangely.

I wasn't able to reproduce the first problem with this ticket. I've asked Jon for further instructions. Let's try and get this one in and I'll do that in a separate PR.