### PR TITLE
VMO-4328 do not remove exits draggable for view mode

### DIFF
--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -145,7 +145,6 @@
             </span>
 
             <span
-              v-if="isEditable"
               class="align-self-center">
               <template v-if="exit.destination_block == null">
                 <plain-draggable
@@ -160,7 +159,7 @@
                   @dragEnded="onCreateExitDragEnded($event, exit)"
                   @destroyed="handleDraggableDestroyedFor(exit)">
                   <i
-                    v-if="exitHovers[exit.uuid]"
+                    v-if="isEditable && exitHovers[exit.uuid]"
                     class="glyphicon glyphicon-move" />
                   <font-awesome-icon
                     v-else
@@ -190,7 +189,7 @@
                   :key="`exit/${exit.uuid}/handle`"
                   class="btn btn-xs btn-flat">
                   <font-awesome-icon
-                    v-if="exitHovers[exit.uuid]"
+                    v-if="isEditable && exitHovers[exit.uuid]"
                     v-b-tooltip.hover.top="trans('flow-builder.tooltip-remove-connection')"
                     class="text-danger"
                     title="Click to remove this connection"


### PR DESCRIPTION
Solution: We should not hide exit draggables on view mode, because connections are bound with them.

[After fix]
![vmo4328](https://user-images.githubusercontent.com/68745918/127247775-03d14cfa-e024-4b1a-bb80-63715ec31b08.gif)
