### PR TITLE
VMO-4367 + VMO-4362 Fix when duplicating multiple blocks doesn't merge metadata

### DIFF
--- a/src/store/flow/flow.ts
+++ b/src/store/flow/flow.ts
@@ -16,7 +16,7 @@ import {IdGeneratorUuidV4} from '@floip/flow-runner/dist/domain/IdGeneratorUuidV
 import moment from 'moment'
 import {ActionTree, GetterTree, MutationTree} from 'vuex'
 import {IRootState} from '@/store'
-import {cloneDeep, defaults, every, forEach, get, has, includes, omit} from 'lodash'
+import {cloneDeep, defaults, every, forEach, get, has, includes, merge, omit} from 'lodash'
 import {discoverContentTypesFor} from '@/store/flow/resource'
 import {computeBlockUiData, computeBlockVendorUiData} from '@/store/builder'
 import {IFlowsState} from '.'
@@ -361,14 +361,15 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
 
     // Set UI positions
     // TODO: remove this once IBlock has vendor_metadata key
-    duplicatedBlock.vendor_metadata = {
+    merge(duplicatedBlock.vendor_metadata, {
       io_viamo: {
         uiData: computeBlockVendorUiData(block),
       },
-    }
-    duplicatedBlock.ui_metadata = {
+    })
+
+    merge(duplicatedBlock.ui_metadata, {
       canvas_coordinates: computeBlockUiData(block),
-    }
+    })
 
     commit('flow_addBlock', {block: duplicatedBlock})
 

--- a/src/store/flow/flow.ts
+++ b/src/store/flow/flow.ts
@@ -360,7 +360,6 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
     }
 
     // Set UI positions
-    // TODO: remove this once IBlock has vendor_metadata key
     merge(duplicatedBlock.vendor_metadata, {
       io_viamo: {
         uiData: computeBlockVendorUiData(block),


### PR DESCRIPTION
This fixes Default showing up on multi-duplicate.

---

<img width="865" alt="Screen Shot 2021-07-27 at 10 09 19 PM" src="https://user-images.githubusercontent.com/58382/127262660-9a181bb3-07d7-4ec0-a680-8e2f8bed5f11.png">
