### PR TITLE
VMO-4210 Keep the block editor's header sticky to the top

### DIFF
--- a/src/components/interaction-designer/block-editors/BlockEditor.vue
+++ b/src/components/interaction-designer/block-editors/BlockEditor.vue
@@ -55,9 +55,19 @@ export default {
   width: 365px;
   overflow-y: scroll;
   padding: 1em;
+  padding-top: 0;
   border: 1px solid lightgray;
   border-radius: 0;
   box-shadow: 0 3px 6px #cacaca;
   transition: right 200ms ease-in-out, 200ms background-color ease-in-out, 200ms border-color ease-in-out, 200ms border-radius ease-in-out;
+}
+
+.block-editor-header {
+  position: sticky;
+  top: 0;
+  background: white;
+  padding-top: 1rem;
+  padding-bottom: 0.25rem;
+  z-index: 15;
 }
 </style>

--- a/src/components/interaction-designer/block-types/ConsoleIO_PrintBlock.vue
+++ b/src/components/interaction-designer/block-types/ConsoleIO_PrintBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="console-io-print-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/ConsoleIO_ReadBlock.vue
+++ b/src/components/interaction-designer/block-types/ConsoleIO_ReadBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="console-io-read-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/Core_CaseBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_CaseBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="core-case-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/Core_LogBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_LogBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="core-log-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
     <fieldset :disabled="!isEditable">

--- a/src/components/interaction-designer/block-types/Core_OutputBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_OutputBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="core-output-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/Core_RunFlowBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_RunFlowBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="core-run-flow-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
     <fieldset :disabled="!isEditable">

--- a/src/components/interaction-designer/block-types/Core_SetContactPropertyBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_SetContactPropertyBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="core-set-contact-property-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/Core_SetGroupMembershipBlock.vue
+++ b/src/components/interaction-designer/block-types/Core_SetGroupMembershipBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="core-set-group-membership-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/MobilePrimitives_MessageBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_MessageBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mobile-primitive-message-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/MobilePrimitives_NumericResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_NumericResponseBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mobile-primitive-numeric-response-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/MobilePrimitives_OpenResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_OpenResponseBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mobile-primitive-open-response-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/MobilePrimitives_SelectManyResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_SelectManyResponseBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mobile-primitive-select-many-response-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
     <fieldset :disabled="!isEditable">

--- a/src/components/interaction-designer/block-types/MobilePrimitives_SelectOneResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/MobilePrimitives_SelectOneResponseBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mobile-primitive-select-one-response-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/SmartDevices_LocationResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/SmartDevices_LocationResponseBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="smart-devices-location-response-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
 

--- a/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
+++ b/src/components/interaction-designer/block-types/SmartDevices_PhotoResponseBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="smart-devices-photo-response-block">
-    <h3 class="no-room-above">
+    <h3 class="block-editor-header">
       {{ `flow-builder.${block.type}` | trans }}
     </h3>
     <fieldset :disabled="!isEditable">

--- a/tests/unit/__snapshots__/storybook.spec.ts.snap
+++ b/tests/unit/__snapshots__/storybook.spec.ts.snap
@@ -71,7 +71,7 @@ exports[`Storyshots ConsoleIo/Read Block Existing Data Non Starting Block 1`] = 
                         class="console-io-read-block"
                       >
                         <h3
-                          class="no-room-above"
+                          class="block-editor-header"
                         >
                           
     Read


### PR DESCRIPTION
![4210](https://user-images.githubusercontent.com/23651142/127351211-ca12e005-127a-4ee6-960e-77b4da49dab5.gif)

@safydy-r I used gif here instead of mov files as you suggested 👍  Thanks for sharing this, it is so much lighter!