### PR TITLE
Vmo 4403 fix toolbar position with scrolling

### DIFF
--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -535,9 +535,13 @@ export default {
     selectBlock() {
       const {block: {uuid: blockId}} = this
       const routerName = this.isBlockEditorOpen ? 'block-selected-details' : 'block-selected'
-      this.$router.history.replace({
+      this.$router.replace({
         name: routerName,
         params: {blockId},
+      }).catch((err) => {
+        if (err.name !== 'NavigationDuplicated') {
+          console.error(err)
+        }
       })
     },
 

--- a/src/components/interaction-designer/BuilderCanvas.vue
+++ b/src/components/interaction-designer/BuilderCanvas.vue
@@ -187,7 +187,7 @@ export default class BuilderCanvas extends Vue {
       return this.windowWidth - this.widthAdjustment
     }
 
-    const xPosition: number = this.blockAtTheLowestPosition.ui_metadata.canvas_coordinates.x
+    const xPosition: number = this.blockAtTheFurthestRightPosition.ui_metadata.canvas_coordinates.x
     const scrollWidth = xPosition + this.blockWidth + MARGIN_WIDTH_CORRECTION
 
     if (scrollWidth < this.windowWidth) {

--- a/src/components/interaction-designer/BuilderCanvas.vue
+++ b/src/components/interaction-designer/BuilderCanvas.vue
@@ -2,7 +2,7 @@
   <div
     v-if="activeFlow"
     class="builder-canvas no-select"
-    :style="{ minWidth: `${canvasWidth}px` , minHeight: `${canvasHeight}px` }">
+    :style="{ minWidth: `${canvasWidth + visibleBlockEditorWidth}px` , minHeight: `${canvasHeight}px` }">
     <block
       v-for="block in activeFlow.blocks"
       :id="`block/${block.uuid}`"
@@ -24,6 +24,7 @@ import {IValidationStatus} from '@/store/validation'
 
 const flowVuexNamespace = namespace('flow')
 const validationVuexNamespace = namespace('validation')
+const builderVuexNamespace = namespace('builder')
 
 //px
 const MARGIN_HEIGHT_CORRECTION = -10
@@ -196,8 +197,15 @@ export default class BuilderCanvas extends Vue {
     return scrollWidth - this.widthAdjustment
   }
 
+  get visibleBlockEditorWidth(): number {
+    const blockEditorWidth = 365
+    return this.isBlockEditorOpen ? blockEditorWidth : 0
+  }
+
   @flowVuexNamespace.State flows?: IFlow[]
   @flowVuexNamespace.Getter activeFlow!: IFlow
+
+  @builderVuexNamespace.State isBlockEditorOpen!: boolean
 
   @validationVuexNamespace.Action validate_flow!: ({flow}: { flow: IFlow }) => Promise<IValidationStatus>
   @validationVuexNamespace.Action validate_block!: ({block}: { block: IBlock }) => Promise<IValidationStatus>

--- a/src/components/interaction-designer/BuilderCanvas.vue
+++ b/src/components/interaction-designer/BuilderCanvas.vue
@@ -2,7 +2,7 @@
   <div
     v-if="activeFlow"
     class="builder-canvas no-select"
-    :style="{ minWidth: `${canvasWidth + visibleBlockEditorWidth}px` , minHeight: `${canvasHeight}px` }">
+    :style="{ minWidth: `${canvasWidth}px` , minHeight: `${canvasHeight}px` }">
     <block
       v-for="block in activeFlow.blocks"
       :id="`block/${block.uuid}`"
@@ -26,13 +26,13 @@ const flowVuexNamespace = namespace('flow')
 const validationVuexNamespace = namespace('validation')
 const builderVuexNamespace = namespace('builder')
 
-//px
+//in `px`
 const MARGIN_HEIGHT_CORRECTION = -10
 
-//px
-const MARGIN_WIDTH_CORRECTION = 50
+//ideal value: the xDelta when we compute xPosition from existing active block, in `px`
+const MARGIN_WIDTH_CORRECTION = 120
 
-//ms
+//in `ms`
 const DEBOUNCE_SCROLL_TIMER = 300
 
 @Component({
@@ -188,7 +188,7 @@ export default class BuilderCanvas extends Vue {
     }
 
     const xPosition: number = this.blockAtTheFurthestRightPosition.ui_metadata.canvas_coordinates.x
-    const scrollWidth = xPosition + this.blockWidth + MARGIN_WIDTH_CORRECTION
+    const scrollWidth = xPosition + this.blockWidth + MARGIN_WIDTH_CORRECTION + this.visibleBlockEditorWidth
 
     if (scrollWidth < this.windowWidth) {
       return this.windowWidth - this.widthAdjustment

--- a/src/components/interaction-designer/block/BlockToolbar.vue
+++ b/src/components/interaction-designer/block/BlockToolbar.vue
@@ -113,6 +113,10 @@ class BlockToolbar extends mixins(Lang) {
     this.$router.replace({
       name: routerName,
       params: {blockId: this.block.uuid},
+    }).catch((err) => {
+      if (err.name !== 'NavigationDuplicated') {
+        console.error(err)
+      }
     })
   }
 

--- a/src/store/builder/index.ts
+++ b/src/store/builder/index.ts
@@ -394,13 +394,10 @@ export function computeBlockUiData(block?: IBlock | null) {
     yPosition = viewPortCenter.y
   }
 
-  const a = {
+  return {
     x: xPosition + xDelta,
     y: yPosition + yDelta,
   }
-
-  console.log('check position rs', xPosition, yPosition, a)
-  return a
 }
 
 export function computeBlockVendorUiData(block?: IBlock | null) {

--- a/src/store/builder/index.ts
+++ b/src/store/builder/index.ts
@@ -394,10 +394,13 @@ export function computeBlockUiData(block?: IBlock | null) {
     yPosition = viewPortCenter.y
   }
 
-  return {
+  const a = {
     x: xPosition + xDelta,
     y: yPosition + yDelta,
   }
+
+  console.log('check position rs', xPosition, yPosition, a)
+  return a
 }
 
 export function computeBlockVendorUiData(block?: IBlock | null) {

--- a/src/views/InteractionDesigner.vue
+++ b/src/views/InteractionDesigner.vue
@@ -313,16 +313,19 @@ export default {
   .interaction-designer-contents {
     background: #F5F5F5;
     min-height: 100vh;
-    display: flex;
-    flex-direction: column;
+    display:inline-block;
     margin: 0;
     padding: 0;
+    border:2px solid green;
   }
 
   .interaction-designer-header {
     position: sticky;
     top: 0;
+    left: 0;
+    display:inline-block;
     z-index: 4*10;
+    border:2px solid red;
   }
 
   .tree-sidebar-container {

--- a/src/views/InteractionDesigner.vue
+++ b/src/views/InteractionDesigner.vue
@@ -316,7 +316,6 @@ export default {
     display:inline-block;
     margin: 0;
     padding: 0;
-    border:2px solid green;
   }
 
   .interaction-designer-header {
@@ -325,7 +324,6 @@ export default {
     left: 0;
     display:inline-block;
     z-index: 4*10;
-    border:2px solid red;
   }
 
   .tree-sidebar-container {


### PR DESCRIPTION
**Note for devs:**
- To make sure the toolbar keeps the position `sticky` and behaves like `fixed`, I used this solution: https://stackoverflow.com/a/57452861/3256489
- I took the opportunity to silent some `NavigationDuplicated` errors like we do with validations https://github.com/FLOIP/flow-builder/blob/VMO-4403-fix-flow-builder-block-editor-position/src/components/interaction-designer/toolbar/ErrorNotifications.vue#L133

**Screenshot**
![vmo-4403](https://user-images.githubusercontent.com/68745918/128958093-dd2f9bc4-313a-4a30-971e-abac2d3fe999.gif)

