### PR TITLE
VMO-5765 fix b-tooltip errors on storyshots

### DIFF
--- a/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
+++ b/src/components/interaction-designer/toolbar/TreeBuilderToolbar.vue
@@ -301,7 +301,7 @@
   </div>
 </template>
 <script lang="ts">
-import {BModal} from 'bootstrap-vue'
+import {BModal, BootstrapVue, BTooltip} from 'bootstrap-vue'
 import Vue from 'vue'
 import Lang from '@/lib/filters/lang'
 import Permissions from '@/lib/mixins/Permissions'
@@ -320,6 +320,9 @@ import {IBlock, IContext, IFlow, IResource} from '@floip/flow-runner'
 import {RawLocation} from 'vue-router'
 import {Dictionary} from 'vue-router/types/router'
 import {Watch} from 'vue-property-decorator'
+
+Vue.use(BootstrapVue)
+Vue.component('BTooltip', BTooltip)
 
 const flowVuexNamespace = namespace('flow')
 const builderVuexNamespace = namespace('builder')

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,13 +12,9 @@ import 'vue-multiselect/dist/vue-multiselect.min.css'
 import 'scss/main.scss'
 
 import registerCustomComponents from '@/common-imports'
-import {BootstrapVue, BTooltip} from 'bootstrap-vue'
 
 import router from './router'
 import App from './App.vue'
-
-Vue.use(BootstrapVue)
-Vue.component('BTooltip', BTooltip)
 
 registerCustomComponents()
 


### PR DESCRIPTION
This has intention to fix 
```
console.error node_modules/vue/dist/vue.common.dev.js:630
    [Vue warn]: Failed to resolve directive: b-tooltip
    
    (found in <TreeBuilderToolbar>)
```

like in https://app.travis-ci.com/github/FLOIP/flow-builder/builds/249587733#L452