### PR TITLE
FEATURE-RELAX-NODE Use node version ^14 as engine constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "deploy": "yarn clean && yarn build-bundle && git add dist/ && git commit -m \"Build + package for release.\" && yarn version --patch && git push origin --tags HEAD"
   },
   "engines": {
-    "node": "^14.19.1"
+    "node": "^14"
   },
   "dependencies": {
     "@avcs/autosuggest": "^1.7.5",


### PR DESCRIPTION
As per discussion on Slack, this is a small change to the package configuration, to use 
```
  "engines": {
    "node": "^14"
  },
```
instead of, as before, `^14.19.1`. 