### PR TITLE
VMO-6428 Move `initiateExtraVendorConfig` invocation

### DIFF
--- a/src/store/flow/block-types/BaseBlock.ts
+++ b/src/store/flow/block-types/BaseBlock.ts
@@ -20,7 +20,6 @@ export const actions = {
     return defaults({
       config: {
         ...props?.config,
-        ...await dispatch('initiateExtraVendorConfig'),
       },
     }, props, {
       type: '',
@@ -35,7 +34,7 @@ export const actions = {
         }, {root: true}),
       ],
       tags: [],
-      vendor_metadata: {},
+      vendor_metadata: await dispatch('initiateExtraVendorConfig'),
     })
   },
 
@@ -53,10 +52,16 @@ export const actions = {
   },
 
   /**
-   * Override this in the consumer side to add extra config props to avoid the validation saying we have missing prop at the creation
-   * eg: {
-   *   prop1: undefined,
-   *   prop2: undefined,
+   * Override this method in the consumer side to add extra config attributes
+   * to avoid the validation saying we have missing prop at the creation.
+   *
+   * Remember to namespace the fields, e.g.:
+   *
+   * return {
+   *   org_example: {
+   *     foo: 1,
+   *     bar: 'baz',
+   *   },
    * }
    */
   async initiateExtraVendorConfig(_ctx: unknown): Promise<object> {

--- a/src/store/flow/block-types/SmartDevices_LocationResponseBlockStore.ts
+++ b/src/store/flow/block-types/SmartDevices_LocationResponseBlockStore.ts
@@ -35,7 +35,6 @@ const actions: ActionTree<IEmptyState, IRootState> = {
       prompt: blankMessageResource.uuid,
       accuracy_threshold_meters: 5.0,
       accuracy_timeout_seconds: 120,
-      ...await dispatch('initiateExtraVendorConfig'),
     }
 
     props.exits = [

--- a/src/store/flow/block-types/SmartDevices_PhotoResponseBlockStore.ts
+++ b/src/store/flow/block-types/SmartDevices_PhotoResponseBlockStore.ts
@@ -15,7 +15,6 @@ const actions: ActionTree<IEmptyState, IRootState> = {
     const blankMessageResource = await dispatch('flow/flow_addBlankResourceForEnabledModesAndLangs', null, {root: true})
     props.config = {
       prompt: blankMessageResource.uuid,
-      ...await dispatch('initiateExtraVendorConfig'),
     }
 
     props.exits = [


### PR DESCRIPTION
We used `initiateExtraVendorConfig` to add extra fields to block config. This PR follows the `vendor_metadata` idea and puts the returned attributes to `block.vendor_metadata` instead.

This PR targets https://github.com/FLOIP/flow-builder/pull/269 because we have app-wide changes there.