### PR TITLE
VMO-6654 consider languages

### DIFF
--- a/src/components/interaction-designer/block-editors/choices/ChoiceMappingModal.vue
+++ b/src/components/interaction-designer/block-editors/choices/ChoiceMappingModal.vue
@@ -61,9 +61,8 @@
                class="tab-pane fade"
                role="tabpanel">
                <div class="mt-3">
-                 <text-mapping-table :block="block"/>
+                 <text-mapping-table :block="block" :lang-id="languageId"/>
                </div>
-
              </div>
            </template>
          </div>

--- a/src/components/interaction-designer/block-editors/choices/TextMappingRow.vue
+++ b/src/components/interaction-designer/block-editors/choices/TextMappingRow.vue
@@ -4,7 +4,7 @@
       {{ choice.name }}
     </td>
     <td>
-      <text-synonyms-editor :block="block" :choice="choice" :index="index" />
+      <text-synonyms-editor :block="block" :choice="choice" :index="index" :lang-id="langId"/>
     </td>
   </tr>
 </template>
@@ -30,6 +30,10 @@ export default {
     },
     index: {
       type: Number,
+      required: true,
+    },
+    langId: {
+      type: String,
       required: true,
     },
   },

--- a/src/components/interaction-designer/block-editors/choices/TextMappingTable.vue
+++ b/src/components/interaction-designer/block-editors/choices/TextMappingTable.vue
@@ -12,7 +12,8 @@
         :key="index"
         :block="block"
         :choice="choice"
-        :index="index" />
+        :index="index"
+        :lang-id="langId" />
     </tbody>
   </table>
 </template>
@@ -29,7 +30,14 @@ export default {
   },
   mixins: [Lang],
   props: {
-    block: {type: ISelectOneResponseBlock, required: true},
+    block: {
+      type: ISelectOneResponseBlock,
+      required: true,
+    },
+    langId: {
+      type: String,
+      required: true,
+    },
   },
 }
 </script>

--- a/src/components/interaction-designer/block-editors/choices/TextSynonymsEditor.vue
+++ b/src/components/interaction-designer/block-editors/choices/TextSynonymsEditor.vue
@@ -1,22 +1,24 @@
 <template>
   <div class="text-synonyms-editor">
-    <validation-message
-      v-for="({
-        test_expression, _language,
-      }, testIndex) in currentTextTestList"
-      :key="testIndex"
-      :message-key="`block/${block.uuid}/config/choices/${index}/text_tests/${testIndex}/test_expression`">
-      <template #input-control="{ isValid }">
-        <expression-input
-          ref="expressionInputs"
-          :current-expression="test_expression"
-          :label="''"
-          :placeholder="trans('flow-builder.enter-expression')"
-          :valid-state="isValid"
-          class="mb-1"
-          @commitExpressionChange="updateCurrentExpression(testIndex, $event)" />
-      </template>
-    </validation-message>
+    <template v-for="({
+        test_expression, language
+      }, testIndex) in currentTextTestList">
+      <validation-message
+        v-if="language === langId"
+        :key="testIndex"
+        :message-key="`block/${block.uuid}/config/choices/${index}/text_tests/${testIndex}/test_expression`">
+        <template #input-control="{ isValid }">
+          <expression-input
+            ref="expressionInputs"
+            :current-expression="test_expression"
+            :label="''"
+            :placeholder="trans('flow-builder.enter-expression')"
+            :valid-state="isValid"
+            class="mb-1"
+            @commitExpressionChange="updateCurrentExpression(testIndex, $event)" />
+        </template>
+      </validation-message>
+    </template>
 
     <!--empty input to add new synonyms-->
     <expression-input
@@ -48,6 +50,10 @@ export default {
     },
     index: {
       type: Number,
+      required: true,
+    },
+    langId: {
+      type: String,
       required: true,
     },
   },
@@ -83,7 +89,7 @@ export default {
         this.choice_setTextTestsExpressionOnIndex({
           choice: this.choice,
           testIndex,
-          languageId: undefined,
+          langId: this.langId,
           value,
         })
       } else {
@@ -94,7 +100,7 @@ export default {
         })
 
         // Hack the dom rendering to make sure we update the UI
-        this.draftExpression = undefined
+        this.draftExpression = value
         this.$nextTick(() => {
           this.draftExpression = ''
         })
@@ -104,9 +110,8 @@ export default {
       this.draftExpression = value
       this.choice_setTextTestsExpressionOnIndex({
         choice: this.choice,
-        choiceIndex: this.index,
         testIndex: Number(this.currentTextTestList.length),
-        languageId: undefined,
+        langId: this.langId,
         value,
       })
 

--- a/src/store/flow/block-types/MobilePrimitives_SelectOneResponseBlockStore.ts
+++ b/src/store/flow/block-types/MobilePrimitives_SelectOneResponseBlockStore.ts
@@ -25,63 +25,6 @@ const actions: ActionTree<IEmptyState, IRootState> = {
   ...baseActions,
   ...ChoiceModule.actions,
 
-  updateChoiceName(
-    {rootGetters, dispatch},
-    {blockId, resourceId, value}: {blockId: IBlock['uuid'], resourceId: IResource['uuid'], value: string},
-  ) {
-    const block: ISelectOneResponseBlock = findBlockWith(blockId, rootGetters['flow/activeFlow']) as ISelectOneResponseBlock
-    const resource: IResource = rootGetters['flow/resourcesByUuidOnActiveFlow'][resourceId]
-
-    if (resource == null) {
-      throw new ValidationException(`Unable to find resource for choice: ${resourceId}`)
-    }
-
-    const choice = find(block.config.choices, (v) => v.prompt === resourceId) as IChoice
-    choice.name = value
-  },
-
-  updateIvrTestExpression(
-    {rootGetters, dispatch},
-    {blockId, resourceId, value}: {blockId: IBlock['uuid'], resourceId: IResource['uuid'], value: string},
-  ) {
-    const block: ISelectOneResponseBlock = findBlockWith(blockId, rootGetters['flow/activeFlow']) as ISelectOneResponseBlock
-    const resource: IResource = rootGetters['flow/resourcesByUuidOnActiveFlow'][resourceId]
-
-    if (resource == null) {
-      throw new ValidationException(`Unable to find resource for choice: ${resourceId}`)
-    }
-
-    const choice = find(block.config.choices, (v) => v.prompt === resourceId) as IChoice
-    Vue.set(choice, 'ivr_test', {})
-    Vue.set(choice.ivr_test as object, 'test_expression', value)
-  },
-
-  block_updateChoiceTextTestsExpressionOn(
-    {rootGetters, dispatch, commit},
-    {blockId, resourceId, value, testIndex}: {blockId: IBlock['uuid'], resourceId: IResource['uuid'], value: string, testIndex: number},
-  ) {
-    const block: ISelectOneResponseBlock = findBlockWith(blockId, rootGetters['flow/activeFlow']) as ISelectOneResponseBlock
-    const resource: IResource = rootGetters['flow/resourcesByUuidOnActiveFlow'][resourceId]
-
-    if (resource == null) {
-      throw new ValidationException(`Unable to find resource for choice: ${resourceId}`)
-    }
-
-    const choice = find(block.config.choices, (v) => v.prompt === resourceId) as IChoice
-
-    // Making sure we have array on text_tests
-    if (choice?.text_tests === undefined) {
-      choice.text_tests = []
-    }
-
-    // TODO VMO-6654 Update test_expression for for all languages
-    commit('choice_updateByPath', {
-      choice,
-      path: `text_tests.[${testIndex}].test_expression`,
-      value,
-    })
-  },
-
   addChoiceByResourceIdTo({rootGetters}, {blockId, resourceId}: { blockId: IBlock['uuid'], resourceId: IResource['uuid'] }) {
     const block: ISelectOneResponseBlock = findBlockWith(blockId, rootGetters['flow/activeFlow']) as ISelectOneResponseBlock
     const resource: IResource = rootGetters['flow/resourcesByUuidOnActiveFlow'][resourceId]

--- a/src/store/flow/block/choice.ts
+++ b/src/store/flow/block/choice.ts
@@ -81,7 +81,7 @@ export const actions: ActionTree<IEmptyState, IRootState> = {
     Vue.set(choice.ivr_test as object, 'test_expression', value)
   },
 
-  // TODO: rename this to init ...
+  // TODO: rename this to init because it's called to init text_test only
   choice_updateTextTestsOn(
     {getters, rootGetters, dispatch, commit},
     {blockId, resourceId, value, langId}: {blockId: IBlock['uuid'], resourceId: IResource['uuid'], value: string, langId: ILanguage['id']},
@@ -90,7 +90,6 @@ export const actions: ActionTree<IEmptyState, IRootState> = {
 
     // Making sure we have array on text_tests
     if (choice?.text_tests === undefined) {
-      console.warn('choice_setTextTestsExpressionOn', 'choice.text_tests was not set')
       choice.text_tests = []
     }
 
@@ -132,7 +131,6 @@ export const actions: ActionTree<IEmptyState, IRootState> = {
     {commit, state, dispatch},
     {choice, testIndex, langId, value}: { choice: IChoice, testIndex: number, langId?: ILanguage['id'], value: string },
   ) {
-    console.debug('test', 'choice_setTextTestsExpressionOnIndex', {choice, testIndex, langId, value})
     if (langId !== undefined) {
       commit('choice_updateByPath', {
         choice,


### PR DESCRIPTION
Addressed checklists:
- Create `text_tests[]` for multiple languages when adding new choices
- Display synonyms for a specific language in a given tab
- Add and Edit synonyms for a specific language from within a tab

@object-required: I don't think we really need choices' vendor_metadata `voice_options` & `text_options`. See my remark at the miro doc (highlighted in red fonts) https://miro.com/app/board/uXjVOiur8ck=/?moveToWidget=3458764530346709331&cot=14

Overview
![vmo-6654 - wip - 2](https://user-images.githubusercontent.com/68745918/183536549-5fdab9c5-1811-4773-9528-87388b47f5fd.gif)

