### PR TITLE
Feature/vmo 5463/vmo 6654/mcq text based mode mapping wip 10aug saf

### DIFF
--- a/src/components/interaction-designer/block-editors/choices/ChoiceMappingModal.vue
+++ b/src/components/interaction-designer/block-editors/choices/ChoiceMappingModal.vue
@@ -18,15 +18,18 @@
              <a
                v-if="hasVoiceMode"
                id="nav-voice-tab"
-               aria-controls="nav-home" aria-selected="true"
-               class="nav-item nav-link active" data-toggle="tab"
+               :class="{'active': hasVoiceMode}"
+               aria-controls="nav-home"
+               aria-selected="true"
+               class="nav-item nav-link"
+               data-toggle="tab"
                href="#nav-voice"
                role="tab">
                {{ trans('flow-builder.voice') }} ({{ trans('flow-builder.all-languages') }})
              </a>
              <template v-if="hasTextMode">
                <a
-                 v-for="({id: languageId, label: language}) in textLanguages"
+                 v-for="({id: languageId, label: language}, index) in textLanguages"
                  :id="`nav-lang-tab-${languageId}`"
                  :key="languageId"
                  :href="`#nav-lang-${languageId}`"
@@ -34,6 +37,7 @@
                  aria-controls="nav-profile"
                  aria-selected="false"
                  class="nav-item nav-link"
+                 :class="{'active': !hasVoiceMode && hasTextMode && index === 0}"
                  data-toggle="tab"
                  role="tab">
                  {{ trans('flow-builder.data-type-text')}} ({{ language || trans('flow-builder.unknown-language') }})
@@ -46,7 +50,8 @@
              v-if="hasVoiceMode"
              id="nav-voice"
              aria-labelledby="nav-voice-tab"
-             class="tab-pane fade show active"
+             :class="{'show active': hasVoiceMode}"
+             class="tab-pane fade"
              role="tabpanel">
              <div class="mt-3">
                <voice-mapping-table :block="block"/>
@@ -54,11 +59,12 @@
            </div>
            <template v-if="hasTextMode">
              <div
-               v-for="({id: languageId, label: language}) in textLanguages"
+               v-for="({id: languageId, label: language}, index) in textLanguages"
                :id="`nav-lang-${languageId}`"
                :key="languageId"
                aria-labelledby="nav-lang-tab"
                class="tab-pane fade"
+               :class="{'show active': !hasVoiceMode && hasTextMode && index === 0}"
                role="tabpanel">
                <div class="mt-3">
                  <text-mapping-table :block="block" :lang-id="languageId"/>

--- a/src/components/interaction-designer/block-editors/choices/ChoicesBuilder.vue
+++ b/src/components/interaction-designer/block-editors/choices/ChoicesBuilder.vue
@@ -50,10 +50,6 @@
     </validation-message>
 
     <choice-mapping-modal :block="block" />
-
-    <small>
-      {{ JSON.stringify(block.config.choices, null, 2) }}
-    </small>
   </div>
 </template>
 

--- a/src/components/interaction-designer/block-editors/choices/ChoicesBuilder.vue
+++ b/src/components/interaction-designer/block-editors/choices/ChoicesBuilder.vue
@@ -59,7 +59,7 @@ import {findOrGenerateStubbedVariantOn} from '@/store/flow/resource'
 import {Component, Prop} from 'vue-property-decorator'
 import {mixins} from 'vue-class-component'
 import Lang from '@/lib/filters/lang'
-import {IBlock, IChoice, IFlow, IResource, IResourceValue, SupportedContentType, SupportedMode, TextTest} from '@floip/flow-runner'
+import {IBlock, IChoice, IFlow, IResource, IResourceValue, SupportedContentType, SupportedMode} from '@floip/flow-runner'
 import {namespace} from 'vuex-class'
 import {ISelectOneResponseBlock} from '@floip/flow-runner/src/model/block/ISelectOneResponseBlock'
 import {BLOCK_TYPE} from '@/store/flow/block-types/MobilePrimitives_SelectOneResponseBlockStore'
@@ -176,7 +176,6 @@ export class ChoicesBuilder extends mixins(Lang) {
 
   @flowVuexNamespace.Getter activeFlow!: IFlow
   @flowVuexNamespace.Action resource_add!: ({resource}: {resource: IResource}) => void
-  // @flowVuexNamespace.Action flow_createBlankResourceForEnabledModesAndLangs!: () => Promise<IResource>
   @flowVuexNamespace.Action resource_createWith!: ({props}: { props: { uuid: string } & Partial<IResource> }) => Promise<IResource>
 
   @blockVuexNamespace.Action deleteChoiceByResourceIdFrom!:

--- a/src/components/interaction-designer/block-editors/choices/ChoicesBuilder.vue
+++ b/src/components/interaction-designer/block-editors/choices/ChoicesBuilder.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import {get, intersectionWith, isEmpty, last} from 'lodash'
+import {intersectionWith, isEmpty, last} from 'lodash'
 import {findOrGenerateStubbedVariantOn} from '@/store/flow/resource'
 import {Component, Prop} from 'vue-property-decorator'
 import {mixins} from 'vue-class-component'

--- a/src/components/interaction-designer/block-editors/choices/TextSynonymsEditor.vue
+++ b/src/components/interaction-designer/block-editors/choices/TextSynonymsEditor.vue
@@ -1,13 +1,14 @@
 <template>
   <div class="text-synonyms-editor">
     <validation-message
-      v-for="({ test_expression, globalIndex }, synonymIndex) in synonymsForLanguage"
+      v-for="({ test_expression, visible_expression, globalIndex }, synonymIndex) in synonymsForLanguage"
       :key="synonymIndex"
       :message-key="`block/${block.uuid}/config/choices/${index}/text_tests/${globalIndex}/test_expression`">
       <template #input-control="{ isValid }">
         <expression-input
           ref="expressionInputs"
-          :current-expression="test_expression"
+          :current-expression="visible_expression"
+          :title="test_expression"
           :label="''"
           :placeholder="trans('flow-builder.enter-expression')"
           :valid-state="isValid"
@@ -31,6 +32,7 @@ import {IChoice, ISelectOneResponseBlock} from '@floip/flow-runner'
 import {mapActions} from 'vuex'
 import {BLOCK_TYPE} from '@/store/flow/block-types/MobilePrimitives_SelectOneResponseBlockStore'
 import Lang from '@/lib/filters/lang'
+import {BLOCK_RESPONSE_EXPRESSION} from '@/store/flow/block/choice'
 
 export default {
   name: 'TextSynonymsEditor',
@@ -65,6 +67,7 @@ export default {
       return this.choiceTests
         .map((text_test, globalIndex) => ({
           ...text_test,
+          visible_expression: this.computeSynonymVisibleExpression(text_test.test_expression),
           globalIndex,
         }))
         .filter(({language}) => language === this.langId)
@@ -129,6 +132,22 @@ export default {
         this.draftExpression = ''
         this.$refs.expressionInputs.at(-1).focus()
       })
+    },
+
+    computeSynonymVisibleExpression(synonymExpression) {
+      const expressionWithoutSpaces = synonymExpression !== undefined ? synonymExpression.replace(/\s/g, '') : undefined
+      const estimatedVisibleExpression = String(expressionWithoutSpaces?.split('\'')?.[1])
+      if (
+        expressionWithoutSpaces.endsWith('\'') === true
+        && (expressionWithoutSpaces?.startsWith(`${BLOCK_RESPONSE_EXPRESSION}='`) === true
+          || expressionWithoutSpaces?.startsWith(`@${BLOCK_RESPONSE_EXPRESSION}='`) === true)
+      ) {
+        if (estimatedVisibleExpression > '') {
+          return estimatedVisibleExpression
+        }
+      }
+
+      return synonymExpression
     },
   },
 }

--- a/src/components/interaction-designer/block-editors/choices/TextSynonymsEditor.vue
+++ b/src/components/interaction-designer/block-editors/choices/TextSynonymsEditor.vue
@@ -62,12 +62,15 @@ export default {
 
   computed: {
     synonymsForLanguage() {
-      return this.choice.text_tests
+      return this.choiceTests
         .map((text_test, globalIndex) => ({
           ...text_test,
           globalIndex,
         }))
         .filter(({language}) => language === this.langId)
+    },
+    choiceTests() {
+      return this.choice.text_tests
     },
   },
 
@@ -83,14 +86,14 @@ export default {
 
   methods: {
     ...mapActions(`flow/${BLOCK_TYPE}`, [
-      'choice_setSymonymForLanguage',
+      'choice_setSynonymForLanguage',
       'choice_removeTextTestsExpressionOnIndex',
     ]),
 
     updateCurrentExpression(testIndex, value) {
       if (value > '') {
         // ADD
-        this.choice_setSymonymForLanguage({
+        this.choice_setSynonymForLanguage({
           blockId: this.block.uuid,
           resourceId: this.choice.prompt,
           language: this.langId,
@@ -114,7 +117,7 @@ export default {
     addNewExpression(value) {
       this.draftExpression = value
 
-      this.choice_setSymonymForLanguage({
+      this.choice_setSynonymForLanguage({
         blockId: this.block.uuid,
         resourceId: this.choice.prompt,
         language: this.langId,

--- a/src/components/interaction-designer/block-editors/choices/mixins/CommonVoiceChoiceConfig.vue
+++ b/src/components/interaction-designer/block-editors/choices/mixins/CommonVoiceChoiceConfig.vue
@@ -2,8 +2,7 @@
 import {mapActions} from 'vuex'
 import {IChoice, ISelectOneResponseBlock} from '@floip/flow-runner'
 import {BLOCK_TYPE} from '@/store/flow/block-types/MobilePrimitives_SelectOneResponseBlockStore'
-
-export const BLOCK_RESPONSE_EXPRESSION = 'block.response'
+import {BLOCK_RESPONSE_EXPRESSION} from '@/store/flow/block/choice'
 
 export default {
   props: {

--- a/src/components/interaction-designer/flow-editors/FlowEditor.vue
+++ b/src/components/interaction-designer/flow-editors/FlowEditor.vue
@@ -130,11 +130,11 @@ export class FlowEditor extends mixins(Lang) {
   @flowVuexNamespace.Mutation flow_setLanguages!: ({flowId, value}: {flowId: string, value: ILanguage | ILanguage[]}) => void
   @flowVuexNamespace.Mutation flow_setSupportedMode!: any
 
-  handleFlowLanguagesAdded(value): void {
+  handleFlowLanguagesAdded(value: ILanguage): void {
     this.block_updateAllBlocksAfterAddingFlowLanguage({language: value})
   }
 
-  handleFlowLanguagesRemoved(value): void {
+  handleFlowLanguagesRemoved(value: ILanguage): void {
     this.block_updateAllBlocksAfterDeletingFlowLanguage({language: value})
   }
 

--- a/src/components/interaction-designer/flow-editors/FlowEditor.vue
+++ b/src/components/interaction-designer/flow-editors/FlowEditor.vue
@@ -110,10 +110,7 @@ export class FlowEditor extends mixins(Lang) {
   }
 
   @flowVuexNamespace.Action block_updateAllBlocksAfterAddingFlowLanguage!: ({language}: {language: ILanguage}) => void
-
-  handleFlowLanguagesAdded(value): Promise<void> {
-    this.block_updateAllBlocksAfterAddingFlowLanguage({language: value})
-  }
+  @flowVuexNamespace.Action block_updateAllBlocksAfterDeletingFlowLanguage!: ({language}: {language: ILanguage}) => void
 
   async updateFlowModes(value: SupportedMode[] | SupportedMode): Promise<void> {
     this.flow_setSupportedMode({flowId: this.flow.uuid, value})
@@ -133,9 +130,14 @@ export class FlowEditor extends mixins(Lang) {
   @flowVuexNamespace.Mutation flow_setLanguages!: ({flowId, value}: {flowId: string, value: ILanguage | ILanguage[]}) => void
   @flowVuexNamespace.Mutation flow_setSupportedMode!: any
 
-  handleFlowLanguagesRemoved(value) {
-    console.debug('test', 'handleFlowLanguagesRemoved', value[0])
+  handleFlowLanguagesAdded(value): void {
+    this.block_updateAllBlocksAfterAddingFlowLanguage({language: value})
   }
+
+  handleFlowLanguagesRemoved(value): void {
+    this.block_updateAllBlocksAfterDeletingFlowLanguage({language: value})
+  }
+
   @builderVuexNamespace.Getter isEditable!: boolean
 
   @validationVuexNamespace.Action validate_allBlocksWithinFlow!: () => Promise<void>

--- a/src/components/interaction-designer/flow-editors/FlowEditor.vue
+++ b/src/components/interaction-designer/flow-editors/FlowEditor.vue
@@ -40,7 +40,9 @@
           :should-hide-validation="!didUserSubmit">
           <languages-editor
             :flow="flow"
-            @commitFlowLanguagesChange="updateFlowLanguages" />
+            @commitFlowLanguagesChange="updateFlowLanguages"
+            @flowLanguagesAdded="handleFlowLanguagesAdded"
+            @flowLanguagesRemoved="handleFlowLanguagesRemoved" />
         </validation-message>
 
         <validation-message
@@ -107,6 +109,12 @@ export class FlowEditor extends mixins(Lang) {
     })
   }
 
+  @flowVuexNamespace.Action block_updateAllBlocksAfterAddingFlowLanguage!: ({language}: {language: ILanguage}) => void
+
+  handleFlowLanguagesAdded(value): Promise<void> {
+    this.block_updateAllBlocksAfterAddingFlowLanguage({language: value})
+  }
+
   async updateFlowModes(value: SupportedMode[] | SupportedMode): Promise<void> {
     this.flow_setSupportedMode({flowId: this.flow.uuid, value})
     // flow modes/languages could have been changed, so
@@ -124,6 +132,10 @@ export class FlowEditor extends mixins(Lang) {
   @flowVuexNamespace.Getter activeFlow!: IFlow
   @flowVuexNamespace.Mutation flow_setLanguages!: ({flowId, value}: {flowId: string, value: ILanguage | ILanguage[]}) => void
   @flowVuexNamespace.Mutation flow_setSupportedMode!: any
+
+  handleFlowLanguagesRemoved(value) {
+    console.debug('test', 'handleFlowLanguagesRemoved', value[0])
+  }
   @builderVuexNamespace.Getter isEditable!: boolean
 
   @validationVuexNamespace.Action validate_allBlocksWithinFlow!: () => Promise<void>

--- a/src/components/interaction-designer/flow-editors/LanguagesEditor.vue
+++ b/src/components/interaction-designer/flow-editors/LanguagesEditor.vue
@@ -32,7 +32,7 @@ export class LanguagesEditor extends mixins(Lang) {
   @Prop() readonly flow!: IFlow
 
   @Watch('flowSelectedLanguages')
-  onLanguagesChange(newValue, oldValue) {
+  onLanguagesChange(newValue: ILanguage[], oldValue: ILanguage[]) {
     if (newValue.length > oldValue.length) {
       const newAddedLanguage = difference(newValue, oldValue)
       this.$emit('flowLanguagesAdded', newAddedLanguage[0])

--- a/src/components/interaction-designer/flow-editors/LanguagesEditor.vue
+++ b/src/components/interaction-designer/flow-editors/LanguagesEditor.vue
@@ -15,12 +15,12 @@
 
 <script lang="ts">
 import VueMultiselect from 'vue-multiselect'
-import {Component, Prop} from 'vue-property-decorator'
+import {Component, Prop, Watch} from 'vue-property-decorator'
 import {IFlow} from '@floip/flow-runner'
 import {ILanguage} from '@floip/flow-runner/dist/flow-spec/ILanguage'
 import Lang from '@/lib/filters/lang'
 import {mixins} from 'vue-class-component'
-import {sortBy} from 'lodash'
+import {difference, sortBy} from 'lodash'
 import {State} from 'vuex-class'
 
 @Component({
@@ -30,6 +30,17 @@ import {State} from 'vuex-class'
 })
 export class LanguagesEditor extends mixins(Lang) {
   @Prop() readonly flow!: IFlow
+
+  @Watch('flowSelectedLanguages')
+  onLanguagesChange(newValue, oldValue) {
+    if (newValue.length > oldValue.length) {
+      const newAddedLanguage = difference(newValue, oldValue)
+      this.$emit('flowLanguagesAdded', newAddedLanguage[0])
+    } else if (newValue.length < oldValue.length) {
+      const newRemovedLanguage = difference(oldValue, newValue)
+      this.$emit('flowLanguagesRemoved', newRemovedLanguage[0])
+    }
+  }
 
   get languages(): ILanguage[] {
     // Make sure to follow order when populating languages, because the order may affect indexes during resource validation

--- a/src/store/flow/block.ts
+++ b/src/store/flow/block.ts
@@ -5,16 +5,19 @@ import {
   IBlock,
   IBlockExit,
   IContext,
+  ILanguage,
 } from '@floip/flow-runner'
 import {ActionTree, GetterTree, MutationTree} from 'vuex'
 import {IRootState} from '@/store'
 import {defaults, has, isArray, isNil, last, reject, snakeCase} from 'lodash'
 import {IdGeneratorUuidV4} from '@floip/flow-runner/dist/domain/IdGeneratorUuidV4'
+import {OutputBranchingType} from '@/components/interaction-designer/block-editors/BlockOutputBranchingConfig.vue'
+import {BLOCK_TYPE as SelectOneBlockType} from '@/store/flow/block-types/MobilePrimitives_SelectOneResponseBlockStore'
+import {BLOCK_TYPE as SelectManyBlockType} from '@/store/flow/block-types/MobilePrimitives_SelectManyResponseBlockStore'
+import {ISelectOneResponseBlock} from '@floip/flow-runner/src/model/block/ISelectOneResponseBlock'
+import * as SetContactPropertyModule from './block/set-contact-property'
 import {IFlowsState} from '.'
 import {removeBlockValueByPath, updateBlockValueByPath} from './utils/vuexBlockHelpers'
-
-import * as SetContactPropertyModule from './block/set-contact-property'
-import {OutputBranchingType} from '@/components/interaction-designer/block-editors/BlockOutputBranchingConfig.vue'
 
 export const getters: GetterTree<IFlowsState, IRootState> = {
   ...SetContactPropertyModule.getters,
@@ -358,6 +361,29 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
   async block_deselect({state}, {blockId}: { blockId: IBlock['uuid'] }) {
     // remove it
     state.selectedBlocks = state.selectedBlocks.filter((item) => item !== blockId)
+  },
+
+  block_updateAllBlocksAfterAddingFlowLanguage({rootGetters, dispatch}, {language}: {language: ILanguage}): void {
+    rootGetters['flow/activeFlow'].blocks.map((currentBlock: IBlock) => {
+      if (currentBlock.type === SelectOneBlockType || currentBlock.type === SelectManyBlockType) {
+        const hasTextMode = rootGetters['flow/hasTextMode']
+        if (hasTextMode === true) {
+          (currentBlock as ISelectOneResponseBlock).config.choices.map((choice) => {
+            choice.text_tests?.push({
+              language: language.id,
+              test_expression: `@block.response = '${choice.name}'`,
+            })
+
+            return choice
+          })
+        }
+      }
+
+      return currentBlock
+    })
+  },
+  async block_updateAllBlocksAfterDeletingFlowLanguages({state}, {blockId}: { blockId: IBlock['uuid'] }) {
+
   },
 }
 

--- a/src/store/flow/block.ts
+++ b/src/store/flow/block.ts
@@ -382,8 +382,22 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
       return currentBlock
     })
   },
-  async block_updateAllBlocksAfterDeletingFlowLanguages({state}, {blockId}: { blockId: IBlock['uuid'] }) {
 
+  block_updateAllBlocksAfterDeletingFlowLanguage({rootGetters, dispatch}, {language}: {language: ILanguage}): void {
+    rootGetters['flow/activeFlow'].blocks.map((currentBlock: IBlock) => {
+      if (currentBlock.type === SelectOneBlockType || currentBlock.type === SelectManyBlockType) {
+        const hasTextMode = rootGetters['flow/hasTextMode']
+        if (hasTextMode === true) {
+          (currentBlock as ISelectOneResponseBlock).config.choices.map((choice) => {
+            choice.text_tests = choice.text_tests?.filter((test) => test.language !== language.id)
+
+            return choice
+          })
+        }
+      }
+
+      return currentBlock
+    })
   },
 }
 

--- a/src/store/flow/block/choice.ts
+++ b/src/store/flow/block/choice.ts
@@ -118,7 +118,7 @@ export const actions: ActionTree<IEmptyState, IRootState> = {
 
     languages.forEach(({id: language}) => {
       // TODO Don't replace if existing value was changed by the user
-      dispatch('choice_setSymonymForLanguage', {
+      dispatch('choice_setSynonymForLanguage', {
         blockId,
         resourceId,
         language,
@@ -135,7 +135,7 @@ export const actions: ActionTree<IEmptyState, IRootState> = {
    * @param param1 action parameters
    * @returns
    */
-  choice_setSymonymForLanguage(
+  choice_setSynonymForLanguage(
     {getters, dispatch},
     {blockId, resourceId, language, index = Number.POSITIVE_INFINITY, value}: { blockId: IBlock['uuid'], resourceId: IResource['uuid'], language: ILanguage['id'], index: number, value: string },
   ) {
@@ -143,7 +143,7 @@ export const actions: ActionTree<IEmptyState, IRootState> = {
     const expressionValue = textValueToExpression(value)
 
     if (choice?.text_tests === undefined) {
-      choice.text_tests = []
+      Vue.set(choice, 'text_tests', [])
     }
 
     let testIndex = 0

--- a/src/store/flow/block/choice.ts
+++ b/src/store/flow/block/choice.ts
@@ -16,11 +16,12 @@ import Vue from 'vue'
 export const BLOCK_RESPONSE_EXPRESSION = 'block.response'
 
 export function textValueToExpression(value: string): string {
-  // TODO Escape single quote in the value
-  // TODO Handle scenario where the @ is in the middle of expression
-  return value.startsWith('@') === true
-    ? value
-    : `@block.response = '${value}'`
+  if (value.includes('@') === true) {
+    return value
+  } else {
+    // Do not accept single quote character for this scenario to make it simple
+    return `@block.response = '${value.replace(/'/g, '')}'`
+  }
 }
 
 export const getters: GetterTree<IEmptyState, IRootState> = {

--- a/src/store/flow/block/choice.ts
+++ b/src/store/flow/block/choice.ts
@@ -17,6 +17,7 @@ export const BLOCK_RESPONSE_EXPRESSION = 'block.response'
 
 export function textValueToExpression(value: string): string {
   // TODO Escape single quote in the value
+  // TODO Handle scenario where the @ is in the middle of expression
   return value.startsWith('@') === true
     ? value
     : `@block.response = '${value}'`


### PR DESCRIPTION
Address changes:
- resolve all reactivity issues
- Fix the TAB active class when not having VOICE mode
- Fix TS errors
- Handle add/remove languages for active flow
- Display expressions, i.e., `@…` synonyms as is; while `@block.response` is displayed as plain text