### PR TITLE
Feature/vmo 6714/update block activation state trigger

### DIFF
--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -45,7 +45,7 @@
           'activated': isBlockActivated,
         }">
         <block-toolbar
-          v-if="isMouseOnBlock || isWaitingForConnection || isAssociatedWithActiveConnectionAsTargetBlock"
+          v-if="shouldShowBlockToolBar"
           :block="block"
           :is-activated-by-connection="isAssociatedWithActiveConnectionAsTargetBlock"
           :is-block-selected="isBlockSelected"
@@ -366,6 +366,14 @@ export class Block extends mixins(Lang) {
     return this.isBlockEditorOpen && this.activeBlockId === this.block.uuid
   }
 
+  @flowNamespace.Action block_updateShouldShowBlockToolBar!: (
+    {blockId, value}: { blockId: string, value: boolean }
+  ) => void
+
+  get shouldShowBlockToolBar(): boolean {
+    return this.block?.vendor_metadata?.floip?.ui_metadata?.should_show_block_tool_bar ?? false
+  }
+
   // todo: how do we decide whether or not this should be an action or a vanilla domain function?
   generateConnectionLayoutKeyFor(source: IBlock, target: IBlock): ConnectionLayout {
     return generateConnectionLayoutKeyFor(source, target)
@@ -391,27 +399,39 @@ export class Block extends mixins(Lang) {
   @builderNamespace.Action setConnectionCreateTargetBlockToNullFrom!: BlockAction
   @builderNamespace.Action applyConnectionCreate!: () => void
 
+  UpdateShouldShowBlockToolBar(): void {
+    this.block_updateShouldShowBlockToolBar({
+      blockId: this.block.uuid,
+      value: this.isMouseOnBlock || this.isWaitingForConnection || this.isAssociatedWithActiveConnectionAsTargetBlock,
+    })
+  }
+
   setIsMouseOnBlock(value: boolean):void {
     this.isMouseOnBlock = value
+    this.UpdateShouldShowBlockToolBar()
   }
 
   exitMouseEnter(exit: IBlockExit): void {
     this.$set(this.exitHovers, exit.uuid, true)
+    this.UpdateShouldShowBlockToolBar()
   }
 
   exitMouseLeave(exit: IBlockExit): void {
     this.$set(this.exitHovers, exit.uuid, false)
+    this.UpdateShouldShowBlockToolBar()
   }
 
   setLineHovered(exit: IBlockExit, value: boolean): void {
     this.$nextTick(() => {
       this.$set(this.lineHovers, exit.uuid, value)
+      this.UpdateShouldShowBlockToolBar()
     })
   }
 
   setLineClicked(exit: IBlockExit, value: boolean): void {
     this.$nextTick(() => {
       this.$set(this.linePermanentlyActive, exit.uuid, value)
+      this.UpdateShouldShowBlockToolBar()
     })
   }
 

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -429,14 +429,12 @@ export class Block extends mixins(Lang) {
   setLineHovered(exit: IBlockExit, value: boolean): void {
     this.$nextTick(() => {
       this.$set(this.lineHovers, exit.uuid, value)
-      this.UpdateShouldShowBlockToolBar()
     })
   }
 
   setLineClicked(exit: IBlockExit, value: boolean): void {
     this.$nextTick(() => {
       this.$set(this.linePermanentlyActive, exit.uuid, value)
-      this.UpdateShouldShowBlockToolBar()
     })
   }
 

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -34,13 +34,6 @@
       @destroyed="handleDraggableDestroyedForBlock"
       @mouseenter.native="isConnectionCreateActive && activateBlockAsDropZone($event)"
       @mouseleave.native="isConnectionCreateActive && deactivateBlockAsDropZone($event)">
-      <block-toolbar
-        :block="block"
-        :is-editor-visible="shouldShowBlockEditor"
-        :is-activated-by-connection="isAssociatedWithActiveConnectionAsTargetBlock"
-        :is-block-selected="isBlockSelected"
-        :is-waiting-for-connection="isWaitingForConnection" />
-
       <header
         :id="`block/${block.uuid}/handle`"
         class="block-target draggable-handle"
@@ -51,6 +44,14 @@
           'rejected': false,
           'activated': isBlockActivated,
         }">
+        <block-toolbar
+          v-if="isMouseOnBlock || isWaitingForConnection || isAssociatedWithActiveConnectionAsTargetBlock"
+          :block="block"
+          :is-activated-by-connection="isAssociatedWithActiveConnectionAsTargetBlock"
+          :is-block-selected="isBlockSelected"
+          :is-editor-visible="shouldShowBlockEditor"
+          :is-waiting-for-connection="isWaitingForConnection" />
+
         <div class="d-flex justify-content-between">
           <p class="block-type">
             {{ trans(`flow-builder.${block.type}`) }}

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -400,13 +400,15 @@ export class Block extends mixins(Lang) {
   @builderNamespace.Action applyConnectionCreate!: () => void
 
   UpdateShouldShowBlockToolBar(): void {
+    //do not show the block toolbar when waiting for connection
+    if (this.isWaitingForConnection) {
+      return
+    }
+
     this.block_updateShouldShowBlockToolBar({
       blockId: this.block.uuid,
-      value: this.isBlockSelected
-        || this.isMouseOnBlock
-        || this.isWaitingForConnection
-        || this.isAssociatedWithActiveConnectionAsTargetBlock,
-    })
+      value: this.isBlockSelected || this.isMouseOnBlock,
+    });
   }
 
   setIsMouseOnBlock(value: boolean):void {

--- a/src/components/interaction-designer/Block.vue
+++ b/src/components/interaction-designer/Block.vue
@@ -402,7 +402,10 @@ export class Block extends mixins(Lang) {
   UpdateShouldShowBlockToolBar(): void {
     this.block_updateShouldShowBlockToolBar({
       blockId: this.block.uuid,
-      value: this.isMouseOnBlock || this.isWaitingForConnection || this.isAssociatedWithActiveConnectionAsTargetBlock,
+      value: this.isBlockSelected
+        || this.isMouseOnBlock
+        || this.isWaitingForConnection
+        || this.isAssociatedWithActiveConnectionAsTargetBlock,
     })
   }
 

--- a/src/components/interaction-designer/Connection.vue
+++ b/src/components/interaction-designer/Connection.vue
@@ -47,6 +47,8 @@ export class Connection extends mixins(Lang) {
   @Prop({type: Object}) readonly target!: IBlock
   @Prop({type: Object}) readonly position!: { x: number, y: number }
   @Prop({type: String}) readonly color!: string
+  // We need to track if the block height has changed, so we can reposition the connection correctly
+  // @Prop({type: String}) readonly didBlockHeightChange!: boolean
 
   // The leader-line library has no types yet
   // No need to set up observers over this

--- a/src/components/interaction-designer/Connection.vue
+++ b/src/components/interaction-designer/Connection.vue
@@ -47,8 +47,6 @@ export class Connection extends mixins(Lang) {
   @Prop({type: Object}) readonly target!: IBlock
   @Prop({type: Object}) readonly position!: { x: number, y: number }
   @Prop({type: String}) readonly color!: string
-  // We need to track if the block height has changed, so we can reposition the connection correctly
-  // @Prop({type: String}) readonly didBlockHeightChange!: boolean
 
   // The leader-line library has no types yet
   // No need to set up observers over this

--- a/src/components/interaction-designer/block-editors/BlockEditor.vue
+++ b/src/components/interaction-designer/block-editors/BlockEditor.vue
@@ -37,7 +37,8 @@ export default BlockEditor
 <style lang="scss">
 .block-editor {
   position: absolute;
-  top: 0;
+  // TODO: Correct this `top` in https://viamoinc.atlassian.net/browse/VMO-6572 if needed
+  top: 30px;
   background: white;
   z-index: 15;
   max-height: 75vh;

--- a/src/components/interaction-designer/blocks/BlockToolbar.vue
+++ b/src/components/interaction-designer/blocks/BlockToolbar.vue
@@ -159,12 +159,12 @@ export default BlockToolbar
   .block-toolbar {
     transition: opacity 100ms ease-in-out;
     background: white;
-    opacity: 0; // default state of hidden
+    //opacity: 0; // default state of hidden
 
-    margin-top: -37.25px;
-    margin-right: -7.5px;
-    margin-left: -7.5px;
-    padding: 5px;
+    //margin-top: -37.25px;
+    //margin-right: -7.5px;
+    //margin-left: -7.5px;
+    //padding: 5px;
 
     border-top: inherit;
     border-right: inherit;
@@ -175,26 +175,26 @@ export default BlockToolbar
 
   &.has-multiple-exits {
     .block-toolbar {
-      margin-right: -7.5px;
+      //margin-right: -7.5px;
     }
   }
 
   &.has-toolbar,
   &:hover {
     .block-toolbar {
-      opacity: 1;
+      //opacity: 1;
     }
   }
 
   &.active {
     .block-toolbar {
-      margin-left: -8.5px;
-      margin-right: -8.5px;
+      //margin-left: -8.5px;
+      //margin-right: -8.5px;
     }
 
     &.has-multiple-exits {
       .block-toolbar {
-        margin-right: -8.5px;
+        //margin-right: -8.5px;
       }
     }
   }
@@ -203,16 +203,16 @@ export default BlockToolbar
     color: #fff;
     background: $success-600;
     border: none;
-    margin-right: -6.5px !important;
-    margin-left: -6.5px !important;
+    //margin-right: -6.5px !important;
+    //margin-left: -6.5px !important;
   }
 
   .target-block-toolbar-activated-by-connection {
     color: #fff;
-    background: $primary-600;
+    background: red;
     border: none;
-    margin-right: -6.5px !important;
-    margin-left: -6.5px !important;
+    //margin-right: -6.5px !important;
+    //margin-left: -6.5px !important;
   }
 }
 </style>

--- a/src/components/interaction-designer/blocks/BlockToolbar.vue
+++ b/src/components/interaction-designer/blocks/BlockToolbar.vue
@@ -30,7 +30,8 @@
           </button>
           <button
             :class="{
-              'text-danger': !isWaitingForConnection && !isActivatedByConnection,
+              'btn-danger': !isWaitingForConnection && !isActivatedByConnection,
+              'btn-secondary': isWaitingForConnection || isActivatedByConnection,
             }"
             class="btn btn-xs ml-1"
             @click.prevent="handleDeleteBlock">

--- a/src/components/interaction-designer/blocks/BlockToolbar.vue
+++ b/src/components/interaction-designer/blocks/BlockToolbar.vue
@@ -1,9 +1,5 @@
 <template>
-  <div :class="{
-      'target-block-toolbar-waiting-for-connection': isWaitingForConnection,
-      'target-block-toolbar-activated-by-connection': isActivatedByConnection
-    }"
-    class="block-toolbar d-flex justify-content-between">
+  <div class="block-toolbar d-flex justify-content-between">
     <div class="header-actions-left">
       <template v-if="isEditable">
         <!--Selection-->
@@ -151,68 +147,3 @@ export class BlockToolbar extends mixins(Lang) {
 }
 export default BlockToolbar
 </script>
-
-<style lang="scss">
-@import "../../../scss/custom_variables";
-
-.block-draggable {
-  .block-toolbar {
-    transition: opacity 100ms ease-in-out;
-    background: white;
-    //opacity: 0; // default state of hidden
-
-    //margin-top: -37.25px;
-    //margin-right: -7.5px;
-    //margin-left: -7.5px;
-    //padding: 5px;
-
-    border-top: inherit;
-    border-right: inherit;
-    border-left: inherit;
-    border-top-right-radius: inherit;
-    border-top-left-radius: inherit;
-  }
-
-  &.has-multiple-exits {
-    .block-toolbar {
-      //margin-right: -7.5px;
-    }
-  }
-
-  &.has-toolbar,
-  &:hover {
-    .block-toolbar {
-      //opacity: 1;
-    }
-  }
-
-  &.active {
-    .block-toolbar {
-      //margin-left: -8.5px;
-      //margin-right: -8.5px;
-    }
-
-    &.has-multiple-exits {
-      .block-toolbar {
-        //margin-right: -8.5px;
-      }
-    }
-  }
-
-  .target-block-toolbar-waiting-for-connection {
-    color: #fff;
-    background: $success-600;
-    border: none;
-    //margin-right: -6.5px !important;
-    //margin-left: -6.5px !important;
-  }
-
-  .target-block-toolbar-activated-by-connection {
-    color: #fff;
-    background: $primary-600;
-    border: none;
-    //margin-right: -6.5px !important;
-    //margin-left: -6.5px !important;
-  }
-}
-</style>

--- a/src/components/interaction-designer/blocks/BlockToolbar.vue
+++ b/src/components/interaction-designer/blocks/BlockToolbar.vue
@@ -209,7 +209,7 @@ export default BlockToolbar
 
   .target-block-toolbar-activated-by-connection {
     color: #fff;
-    background: red;
+    background: $primary-600;
     border: none;
     //margin-right: -6.5px !important;
     //margin-left: -6.5px !important;

--- a/src/store/builder/index.ts
+++ b/src/store/builder/index.ts
@@ -350,6 +350,9 @@ export function generateConnectionLayoutKeyFor(source: IBlock, target: IBlock): 
     source.label,
     target.label,
 
+    // states that would affect block heights
+    source?.vendor_metadata?.floip?.ui_metadata?.should_show_block_tool_bar,
+
     // todo: this needs to be a computed prop // possibly on store as getter by blockId ?
 
     // other exit titles

--- a/src/store/flow/block.ts
+++ b/src/store/flow/block.ts
@@ -351,8 +351,9 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
     ]
   },
 
-  async block_select({state}, {blockId}: { blockId: IBlock['uuid'] }) {
+  async block_select({state, dispatch}, {blockId}: { blockId: IBlock['uuid'] }) {
     state.selectedBlocks.push(blockId)
+    dispatch('block_updateShouldShowBlockToolBar', {blockId, value: true})
   },
 
   async block_deselect({state}, {blockId}: { blockId: IBlock['uuid'] }) {

--- a/src/store/flow/block.ts
+++ b/src/store/flow/block.ts
@@ -359,6 +359,14 @@ export const actions: ActionTree<IFlowsState, IRootState> = {
     // remove it
     state.selectedBlocks = state.selectedBlocks.filter((item) => item !== blockId)
   },
+
+  block_updateShouldShowBlockToolBar({state, commit}, {blockId, value}: { blockId: string, path: string, value: boolean }): void {
+    commit('block_updateVendorMetadataByPath', {
+      blockId,
+      path: 'floip.ui_metadata.should_show_block_tool_bar',
+      value,
+    })
+  },
 }
 
 export interface IDeepBlockExitIdWithinFlow {


### PR DESCRIPTION
[Note for reviewers]
- the main change is to bring the block-toolbar inside the block-draggable, and try to reposition the connection start position because the exit might change
- another thing to consider: I've made a change about block colours, because I made a mistake by referring to a wrong dsn ([dns-261's iteration page](https://www.figma.com/file/nNnjLfJvgh44ZRpmxcb4jz/VMO-5668-%26-DSN-261%3A-Flow-Builder-in-Viamo-context?node-id=1%3A2)) instead of "[dsn-261's block states page](https://www.figma.com/file/nNnjLfJvgh44ZRpmxcb4jz/VMO-5668-%26-DSN-261%3A-Flow-Builder-in-Viamo-context)" which is linked with vmo-6573

@object-required / @bulatgab That dsn reference is very important !

[Overview]
![vmo-6714 - for pr](https://user-images.githubusercontent.com/68745918/185726194-496797c4-b7f3-464d-b219-e286be4e9e88.gif)

