### PR TITLE
Feature/vmo 6851/vmo 7116/group resource UI by channel

### DIFF
--- a/src/components/interaction-designer/resource-editors/HorizontalResourceEditor.vue
+++ b/src/components/interaction-designer/resource-editors/HorizontalResourceEditor.vue
@@ -64,10 +64,11 @@ import {sortBy} from 'lodash'
 const flowVuexNamespace = namespace('flow')
 
 @Component({})
-export class ResourceEditor extends mixins(FlowUploader, Permissions, Routes, Lang) {
+export class HorizontalResourceEditor extends mixins(FlowUploader, Permissions, Routes, Lang) {
   @Prop({required: true}) block!: IBlock
 
   @flowVuexNamespace.Getter activeFlow!: IFlow
+  @flowVuexNamespace.Getter supportedModeWithOrderInfo!: {mode: SupportedMode, index: number, order: number}[]
 
   SupportedMode = SupportedMode
   iconsMap = new Map<string, object>([
@@ -78,30 +79,9 @@ export class ResourceEditor extends mixins(FlowUploader, Permissions, Routes, La
     [SupportedMode.RICH_MESSAGING, ['far', 'comment-dots']],
     [SupportedMode.OFFLINE, ['fas', 'mobile-alt']],
   ])
-
-  get supportedModeWithOrderInfo() {
-    return this.activeFlow.supported_modes.map((item, key) => ({
-        mode: item,
-        index: key,
-        order: this.computeChannelDisplayOrder(item),
-      }))
-  }
-
-  computeChannelDisplayOrder(mode: SupportedMode) {
-    const order = [
-      SupportedMode.IVR,
-      SupportedMode.SMS,
-      SupportedMode.USSD,
-      SupportedMode.TEXT,
-      SupportedMode.RICH_MESSAGING,
-      SupportedMode.OFFLINE,
-    ]
-    const orderedSupportedMode = sortBy(this.activeFlow.supported_modes, (o) => order.indexOf(o))
-    return orderedSupportedMode.indexOf(mode)
-  }
 }
 
-export default ResourceEditor
+export default HorizontalResourceEditor
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/interaction-designer/resource-editors/HorizontalResourceEditor.vue
+++ b/src/components/interaction-designer/resource-editors/HorizontalResourceEditor.vue
@@ -1,25 +1,35 @@
 <template>
   <div
-    v-if="activeFlow.languages.length > 0"
+    v-if="activeFlow.supported_modes.length > 0"
     class="horizontal-resource-editor">
     <div>
-      <div v-for="({id: languageId, label: language}, langIndex) in activeFlow.languages"
-           :key="languageId"
+      <div v-for="(mode, modeIndex) in activeFlow.supported_modes"
+           :key="modeIndex"
            :class="{
-             'radius-on-top': langIndex === 0,
-             'radius-on-bottom': langIndex === activeFlow.languages.length - 1
+             'radius-on-top': modeIndex === 0,
+             'radius-on-bottom': modeIndex === activeFlow.supported_modes.length - 1
            }"
-           class="language-panel">
+           class="resource-panel">
         <div :class="{
-             'radius-on-top': langIndex === 0,
-             'radius-on-bottom': langIndex === activeFlow.languages.length - 1
+             'radius-on-top': modeIndex === 0,
+             'radius-on-bottom': modeIndex === activeFlow.supported_modes.length - 1
            }"
-             class="language-panel-heading p-2 d-flex">
-          <div class="mr-auto">{{language || 'flow-builder.unknown-language' | trans}}</div>
+             class="resource-panel-heading p-2 d-flex">
+          <div class="mr-auto">
+            <header class="d-flex">
+              <font-awesome-icon
+                v-if="iconsMap.get(mode)"
+                :class="{'custom-icons': iconsMap.get(mode)[0] === 'fac', 'library-icons': iconsMap.get(mode)[0] !== 'fac'}"
+                :icon="iconsMap.get(mode)" />
+              <h6 class="ml-1">
+                {{ `flow-builder.${mode.toLowerCase()}-content` | trans }}
+              </h6>
+            </header>
+          </div>
           <div class="ml-auto">
             <button
-              :aria-controls="`collapse-lang-panel-${block.uuid}-${languageId}`"
-              :data-target="`#collapse-lang-panel-${block.uuid}-${languageId}`"
+              :aria-controls="`collapse-lang-panel-${block.uuid}-${mode}`"
+              :data-target="`#collapse-lang-panel-${block.uuid}-${mode}`"
               aria-expanded="false"
               class="btn btn-sm btn-primary"
               data-toggle="collapse"
@@ -28,12 +38,11 @@
             </button>
           </div>
         </div>
-        <div :id="`collapse-lang-panel-${block.uuid}-${languageId}`" class="language-panel-body p-2 collapse multi-collapse">
-          <language-resource-editor
+        <div :id="`collapse-lang-panel-${block.uuid}-${mode}`" class="resource-panel-body p-2 collapse multi-collapse">
+          <mode-resource-editor
             :block="block"
-            :language-id="languageId"
-            :language-index="langIndex"
-            :resource-display-type="'horizontal'"/>
+            :mode="mode"
+            :mode-index="modeIndex" />
         </div>
       </div>
     </div>
@@ -41,11 +50,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
 import {namespace} from 'vuex-class'
 import {
   IBlock,
   IFlow,
+  SupportedMode,
 } from '@floip/flow-runner'
 import Lang from '@/lib/filters/lang'
 import Permissions from '@/lib/mixins/Permissions'
@@ -53,9 +62,6 @@ import Routes from '@/lib/mixins/Routes'
 import FlowUploader from '@/lib/mixins/FlowUploader'
 import {Component, Prop} from 'vue-property-decorator'
 import {mixins} from 'vue-class-component'
-import {TabsPlugin} from 'bootstrap-vue'
-
-Vue.use(TabsPlugin)
 
 const flowVuexNamespace = namespace('flow')
 
@@ -64,6 +70,16 @@ export class ResourceEditor extends mixins(FlowUploader, Permissions, Routes, La
   @Prop({required: true}) block!: IBlock
 
   @flowVuexNamespace.Getter activeFlow!: IFlow
+
+  SupportedMode = SupportedMode
+  iconsMap = new Map<string, object>([
+    [SupportedMode.SMS, ['far', 'envelope']],
+    [SupportedMode.TEXT, ['fac', 'text']],
+    [SupportedMode.USSD, ['fac', 'ussd']],
+    [SupportedMode.IVR, ['fac', 'audio']],
+    [SupportedMode.RICH_MESSAGING, ['far', 'comment-dots']],
+    [SupportedMode.OFFLINE, ['fas', 'mobile-alt']],
+  ])
 }
 
 export default ResourceEditor
@@ -72,7 +88,7 @@ export default ResourceEditor
 <style lang="scss" scoped>
 @import "../../../scss/custom_variables";
 
-.language-panel {
+.resource-panel {
   margin-top: -1px; /** To avoid bold border separator on multiple languages **/
   border: 1px solid $neutral-200;
 }
@@ -87,11 +103,11 @@ export default ResourceEditor
   border-bottom-right-radius: 6px;
 }
 
-.language-panel-heading {
+.resource-panel-heading {
   background-color: white;
 }
 
-.language-panel-body {
+.resource-panel-body {
   border-top: 1px solid $neutral-200;
 }
 </style>

--- a/src/components/interaction-designer/resource-editors/HorizontalResourceEditor.vue
+++ b/src/components/interaction-designer/resource-editors/HorizontalResourceEditor.vue
@@ -2,34 +2,35 @@
   <div
     v-if="activeFlow.supported_modes.length > 0"
     class="horizontal-resource-editor">
-    <div>
-      <div v-for="(mode, modeIndex) in activeFlow.supported_modes"
-           :key="modeIndex"
+    <div class="d-flex flex-column">
+      <div v-for="(item) in supportedModeWithOrderInfo"
+           :key="item.index"
            :class="{
-             'radius-on-top': modeIndex === 0,
-             'radius-on-bottom': modeIndex === activeFlow.supported_modes.length - 1
+             [`order-${item.order}`]: true,
+             'radius-on-top': item.order === 0,
+             'radius-on-bottom': item.order === activeFlow.supported_modes.length - 1
            }"
            class="resource-panel">
         <div :class="{
-             'radius-on-top': modeIndex === 0,
-             'radius-on-bottom': modeIndex === activeFlow.supported_modes.length - 1
+             'radius-on-top': item.order === 0,
+             'radius-on-bottom': item.order === activeFlow.supported_modes.length - 1,
            }"
              class="resource-panel-heading p-2 d-flex">
           <div class="mr-auto">
             <header class="d-flex">
               <font-awesome-icon
-                v-if="iconsMap.get(mode)"
-                :class="{'custom-icons': iconsMap.get(mode)[0] === 'fac', 'library-icons': iconsMap.get(mode)[0] !== 'fac'}"
-                :icon="iconsMap.get(mode)" />
+                v-if="iconsMap.get(item.mode)"
+                :class="{'custom-icons': iconsMap.get(item.mode)[0] === 'fac', 'library-icons': iconsMap.get(item.mode)[0] !== 'fac'}"
+                :icon="iconsMap.get(item.mode)" />
               <h6 class="ml-1">
-                {{ `flow-builder.${mode.toLowerCase()}-content` | trans }}
+                {{ `flow-builder.${item.mode.toLowerCase()}-content` | trans }}
               </h6>
             </header>
           </div>
           <div class="ml-auto">
             <button
-              :aria-controls="`collapse-lang-panel-${block.uuid}-${mode}`"
-              :data-target="`#collapse-lang-panel-${block.uuid}-${mode}`"
+              :aria-controls="`collapse-lang-panel-${block.uuid}-${item.mode}`"
+              :data-target="`#collapse-lang-panel-${block.uuid}-${item.mode}`"
               aria-expanded="false"
               class="btn btn-sm btn-primary"
               data-toggle="collapse"
@@ -38,11 +39,11 @@
             </button>
           </div>
         </div>
-        <div :id="`collapse-lang-panel-${block.uuid}-${mode}`" class="resource-panel-body p-2 collapse multi-collapse">
+        <div :id="`collapse-lang-panel-${block.uuid}-${item.mode}`" class="resource-panel-body p-2 collapse multi-collapse">
           <mode-resource-editor
             :block="block"
-            :mode="mode"
-            :mode-index="modeIndex" />
+            :mode="item.mode"
+            :mode-index="item.index" />
         </div>
       </div>
     </div>
@@ -51,17 +52,14 @@
 
 <script lang="ts">
 import {namespace} from 'vuex-class'
-import {
-  IBlock,
-  IFlow,
-  SupportedMode,
-} from '@floip/flow-runner'
+import {IBlock, IFlow, SupportedMode,} from '@floip/flow-runner'
 import Lang from '@/lib/filters/lang'
 import Permissions from '@/lib/mixins/Permissions'
 import Routes from '@/lib/mixins/Routes'
 import FlowUploader from '@/lib/mixins/FlowUploader'
 import {Component, Prop} from 'vue-property-decorator'
 import {mixins} from 'vue-class-component'
+import {sortBy} from 'lodash'
 
 const flowVuexNamespace = namespace('flow')
 
@@ -80,6 +78,27 @@ export class ResourceEditor extends mixins(FlowUploader, Permissions, Routes, La
     [SupportedMode.RICH_MESSAGING, ['far', 'comment-dots']],
     [SupportedMode.OFFLINE, ['fas', 'mobile-alt']],
   ])
+
+  get supportedModeWithOrderInfo() {
+    return this.activeFlow.supported_modes.map((item, key) => ({
+        mode: item,
+        index: key,
+        order: this.computeChannelDisplayOrder(item),
+      }))
+  }
+
+  computeChannelDisplayOrder(mode: SupportedMode) {
+    const order = [
+      SupportedMode.IVR,
+      SupportedMode.SMS,
+      SupportedMode.USSD,
+      SupportedMode.TEXT,
+      SupportedMode.RICH_MESSAGING,
+      SupportedMode.OFFLINE,
+    ]
+    const orderedSupportedMode = sortBy(this.activeFlow.supported_modes, (o) => order.indexOf(o))
+    return orderedSupportedMode.indexOf(mode)
+  }
 }
 
 export default ResourceEditor

--- a/src/components/interaction-designer/resource-editors/ModeResourceEditor.vue
+++ b/src/components/interaction-designer/resource-editors/ModeResourceEditor.vue
@@ -102,7 +102,7 @@ const flowVuexNamespace = namespace('flow')
 const builderVuexNamespace = namespace('builder')
 
 @Component({})
-export class LanguageResourceEditor extends mixins(FlowUploader, Permissions, Routes, Lang) {
+export class ModeResourceEditor extends mixins(FlowUploader, Permissions, Routes, Lang) {
   @Prop({required: true}) block!: IBlock
   @Prop({required: true}) modeIndex!: string
   @Prop({required: true}) mode!: string
@@ -216,7 +216,7 @@ export class LanguageResourceEditor extends mixins(FlowUploader, Permissions, Ro
     }
   }
 }
-export default LanguageResourceEditor
+export default ModeResourceEditor
 </script>
 
 <style scoped>

--- a/src/components/interaction-designer/resource-editors/ModeResourceEditor.vue
+++ b/src/components/interaction-designer/resource-editors/ModeResourceEditor.vue
@@ -1,25 +1,15 @@
 <template>
-  <!--Resource editors grouped by language-->
+  <!--Resource editors grouped by mode (channel)-->
   <div v-if="resource"
-       :class="{'d-flex': isHorizontalDisplay}"
-       class="language-resource-editor">
-    <div
-      v-for="(mode, modeIndex) in activeFlow.supported_modes"
-      :key="modeIndex"
-      :class="{'col-3': isHorizontalDisplay}">
+       class="mode-resource-editor d-flex">
+    <div v-for="({id: languageId, label: language}, languageIndex) in activeFlow.languages"
+         :key="languageId"
+         class="col-3">
       <header class="d-flex">
-        <font-awesome-icon
-          v-if="iconsMap.get(mode)"
-          :class="{'custom-icons': iconsMap.get(mode)[0] === 'fac', 'library-icons': iconsMap.get(mode)[0] !== 'fac'}"
-          :icon="iconsMap.get(mode)" />
-        <h6 class="ml-1">
-          {{ `flow-builder.${mode.toLowerCase()}-content` | trans }}
-        </h6>
+        <div class="mr-auto">{{language || trans('flow-builder.unknown-language')}}</div>
       </header>
 
       <template v-for="contentType in discoverContentTypesFor(mode)">
-        <!-- todo: it's odd that we pass around a ContentType variant rather than a ContentTypeLangMode variant (aka, mode as external arg) -->
-
         <resource-variant-text-editor
           v-if="contentType === SupportedContentType.TEXT"
           :index="computeResourceIndex(languageIndex, modeIndex)"
@@ -94,7 +84,6 @@ import {
   IBlock,
   IFlow,
   IResource,
-  IResourceValue as IResourceDefinitionVariantOverModes,
   SupportedContentType,
   SupportedMode,
 } from '@floip/flow-runner'
@@ -115,20 +104,11 @@ const builderVuexNamespace = namespace('builder')
 @Component({})
 export class LanguageResourceEditor extends mixins(FlowUploader, Permissions, Routes, Lang) {
   @Prop({required: true}) block!: IBlock
-  @Prop({required: true}) languageIndex!: string
-  @Prop({required: true}) languageId!: string
-  @Prop({required: false, default: 'vertical'}) resourceDisplayType!: string
+  @Prop({required: true}) modeIndex!: string
+  @Prop({required: true}) mode!: string
 
   SupportedMode = SupportedMode
   SupportedContentType = SupportedContentType
-  iconsMap = new Map<string, object>([
-    [SupportedMode.SMS, ['far', 'envelope']],
-    [SupportedMode.TEXT, ['fac', 'text']],
-    [SupportedMode.USSD, ['fac', 'ussd']],
-    [SupportedMode.IVR, ['fac', 'audio']],
-    [SupportedMode.RICH_MESSAGING, ['far', 'comment-dots']],
-    [SupportedMode.OFFLINE, ['fas', 'mobile-alt']],
-  ])
 
   discoverContentTypesFor = discoverContentTypesFor
   findOrGenerateStubbedVariantOn = findOrGenerateStubbedVariantOn

--- a/src/components/interaction-designer/resource-editors/ModeResourceEditor.vue
+++ b/src/components/interaction-designer/resource-editors/ModeResourceEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <!--Resource editors grouped by mode (channel)-->
   <div v-if="resource"
-       class="mode-resource-editor d-flex">
+       class="mode-resource-editor d-flex flex-wrap">
     <div v-for="({id: languageId, label: language}, languageIndex) in activeFlow.languages"
          :key="languageId"
          class="col-3">

--- a/src/components/interaction-designer/resource-editors/ResourceVariantTextEditor.vue
+++ b/src/components/interaction-designer/resource-editors/ResourceVariantTextEditor.vue
@@ -2,7 +2,7 @@
   <validation-message
     :message-key="`resource/${resourceId}/values/${index}/value`">
     <template #input-control="{ isValid }">
-      <div class="resource-variant-text-editor">
+      <div class="resource-variant-text-editor mb-0">
         <expression-input
           ref="input"
           :label="label"
@@ -12,7 +12,8 @@
           :rows="rows"
           :valid-state="isValid"
           :disabled-auto-complete="disabledAutoComplete"
-          @commitExpressionChange="commitExpressionChange" />
+          class="mb-0"
+          @commitExpressionChange="commitExpressionChange"/>
       </div>
     </template>
   </validation-message>

--- a/src/components/interaction-designer/resource-editors/index.ts
+++ b/src/components/interaction-designer/resource-editors/index.ts
@@ -1,5 +1,6 @@
-export * from './ResourceEditor.vue'
-export * from './ResourceVariantTextEditor.vue'
 export {default as HorizontalResourceEditor} from './HorizontalResourceEditor.vue'
 export {default as LanguageResourceEditor} from './LanguageResourceEditor.vue'
+export {default as ModeResourceEditor} from './ModeResourceEditor.vue'
 export * from './ResourceEditor.model'
+export * from './ResourceEditor.vue'
+export * from './ResourceVariantTextEditor.vue'

--- a/src/store/flow/flow.ts
+++ b/src/store/flow/flow.ts
@@ -75,6 +75,28 @@ export const getters: GetterTree<IFlowsState, IRootState> = {
   hasVoiceMode: (state, getters) => includes(getters.activeFlow.supported_modes || [], SupportedMode.IVR),
   hasOfflineMode: (state, getters) => includes(getters.activeFlow.supported_modes || [], SupportedMode.OFFLINE),
   currentFlowsState: (state) => state,
+  /**
+   * supportedModeWithOrderInfo for UI display
+   */
+  supportedModeWithOrderInfo: (state, getters) => getters.activeFlow.supported_modes.map((item: SupportedMode, key: number) => ({
+    mode: item,
+    index: key,
+    order: getters.orderedSupportedModes.indexOf(item),
+  })),
+  /**
+   * orderedSupportedModes for UI display
+   */
+  orderedSupportedModes: (state, getters) => {
+    const order = [
+      SupportedMode.IVR,
+      SupportedMode.SMS,
+      SupportedMode.USSD,
+      SupportedMode.TEXT,
+      SupportedMode.RICH_MESSAGING,
+      SupportedMode.OFFLINE,
+    ]
+    return sortBy(getters.activeFlow.supported_modes, (item: SupportedMode) => order.indexOf(item))
+  },
 }
 
 export const mutations: MutationTree<IFlowsState> = {


### PR DESCRIPTION
TODO:
- will fix the validations on multiple languages (more than 3) in https://viamoinc.atlassian.net/browse/VMO-7102

Note for reviewer:
- For order, I used the `d-flex order` feature, that way we don't need to make hard refactor in the code base. Beside, the resource validation rely on a specific order.

[Overview]
Resource view
<img width="1144" alt="Screen Shot 2022-09-28 at 8 51 07 AM" src="https://user-images.githubusercontent.com/68745918/192814500-065cb724-d5d5-4138-8dfb-473f8eedc1c8.png">

Block config: To see the order (IVR first)
![Screen Shot 2022-09-27 at 7 01 39 PM](https://user-images.githubusercontent.com/68745918/192814847-22c0a9c9-c2f9-4ce5-bbb1-bcc2fa81c0b2.png)
