### PR TITLE
CORE-310 add notification module

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "vue-multiselect": "^2.1.6",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.5.4",
+    "vue-toastification": "^1.7.14",
     "vuex": "^3.6.2",
     "vuex-class": "^0.3.2"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,12 +13,15 @@ import 'scss/main.scss'
 
 import registerCustomComponents from '@/common-imports'
 
+import Toast from 'vue-toastification'
 import router from './router'
 import App from './App.vue'
+import 'vue-toastification/dist/index.css'
 
 registerCustomComponents()
 
 Vue.use(Vuex)
+Vue.use(Toast)
 
 Vue.config.productionTip = false
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import {IClipboardState, store as clipboard} from '@/store/clipboard'
 import {IFlowsState, store as flow} from './flow'
 import {IBuilderState, store as builder} from './builder'
 import {IValidationState, validationStore as validation} from './validation'
+import notification from './notification'
 
 export interface IRootState {
   builder: IBuilderState,
@@ -13,6 +14,7 @@ export interface IRootState {
   trees: any,
   audio: any,
   clipboard: IClipboardState,
+  notification: any,
 }
 
 export const store: StoreOptions<IRootState> = {
@@ -24,6 +26,7 @@ export const store: StoreOptions<IRootState> = {
     trees,
     audio,
     clipboard,
+    notification,
   },
 }
 

--- a/src/store/notification/index.ts
+++ b/src/store/notification/index.ts
@@ -1,0 +1,87 @@
+import Vue from 'vue'
+import {ActionTree, Module} from 'vuex'
+import {IRootState} from '@/store'
+import {ToastOptions} from 'vue-toastification/dist/types/src/types'
+import {POSITION} from 'vue-toastification/src/ts/constants'
+import {TYPE} from 'vue-toastification/dist/types/src/ts/constants'
+
+/**
+ * For more details about available options, see https://vue-toastification.maronato.dev/
+ */
+const GENERAL_OPTIONS: ToastOptions = {
+  position: POSITION.TOP_RIGHT,
+  draggable: true,
+  draggablePercent: 0.6,
+  closeOnClick: false,
+  timeout: false,
+}
+
+/**
+ * Note, we can use a custom component for `content`, not only texts
+ */
+export type IToastContent = string | object
+
+export interface IToast {
+  content: IToastContent,
+  options: ToastOptions,
+}
+
+export interface INotificationState {}
+
+export const stateFactory = (): INotificationState => ({})
+
+export const notificationActions: ActionTree<INotificationState, IRootState> = {
+  toast(_context, {content, options}: IToast) {
+    Vue.$toast(content, {
+      ...GENERAL_OPTIONS,
+      ...options,
+    } as ToastOptions)
+  },
+  toastError({dispatch}, {content, options}: IToast) {
+    const defaultOptions: ToastOptions = {} as ToastOptions
+    Vue.$toast.error(content, {
+      ...GENERAL_OPTIONS,
+      ...defaultOptions,
+      ...options,
+    } as (ToastOptions & {
+      type?: TYPE.ERROR | undefined
+    }) | undefined)
+  },
+  toastSuccess({dispatch}, {content, options}: IToast) {
+    const defaultOptions = {}
+    Vue.$toast.success(content, {
+      ...GENERAL_OPTIONS,
+      ...defaultOptions,
+      ...options,
+    } as (ToastOptions & {
+      type?: TYPE.SUCCESS | undefined
+    }) | undefined)
+  },
+  toastInfo({dispatch}, {content, options}: IToast) {
+    const defaultOptions = {}
+    Vue.$toast.info(content, {
+      ...GENERAL_OPTIONS,
+      ...defaultOptions,
+      ...options,
+    } as (ToastOptions & {
+      type?: TYPE.INFO | undefined
+    }) | undefined)
+  },
+  toastWarning({dispatch}, {content, options}: IToast) {
+    const defaultOptions = {}
+    Vue.$toast.warning(content, {
+      ...GENERAL_OPTIONS,
+      ...defaultOptions,
+      ...options,
+    } as (ToastOptions & {
+      type?: TYPE.WARNING | undefined
+    }) | undefined)
+  },
+}
+
+export const notificationStore: Module<INotificationState, IRootState> = {
+  state: stateFactory,
+  actions: notificationActions,
+}
+
+export default notificationStore

--- a/yarn.lock
+++ b/yarn.lock
@@ -3561,6 +3561,7 @@ __metadata:
     vue-property-decorator: ^9.1.2
     vue-router: ^3.5.4
     vue-template-compiler: ^2.7.8
+    vue-toastification: ^1.7.14
     vue-tsc: ^0.40.13
     vuex: ^3.6.2
     vuex-class: ^0.3.2
@@ -28362,6 +28363,15 @@ jgexml@latest:
   version: 1.9.1
   resolution: "vue-template-es2015-compiler@npm:1.9.1"
   checksum: ad1e85662783be3ee262c323b05d12e6a5036fca24f16dc0f7ab92736b675919cb4fa4b79b28753eac73119b709d1b36789bf60e8ae423f50c4db35de9370e8b
+  languageName: node
+  linkType: hard
+
+"vue-toastification@npm:^1.7.14":
+  version: 1.7.14
+  resolution: "vue-toastification@npm:1.7.14"
+  peerDependencies:
+    vue: ^2.0.0
+  checksum: 1a95ba3d1bb4a387ab938e2f61568950f9a3bb5a8e4009d856bd65d1da33827b5dc2bb0c181bc269391ca6389d69cc1541d809eca1d28613a0b0b440c6d1082b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Summary:
I just added a notification module to wrap the `vue-toastification` options with a `GENERAL_OPTIONS`, which will help us to just call something like this later.
```
    this.toastError({
      content: 'test error!',
      options: {
        position: 'top-center',
      },
    })
    this.toastSuccess({
      content: 'test success!',
    })
    this.toastWarning({
      content: 'test warning!',
    })
    this.toastInfo({
      content: 'test info!',
      options: {
        timeout: 5000,
      },
    })
```
These are example of action dispatches from a vue component, which give us this kind of render
![core-310](https://user-images.githubusercontent.com/68745918/224191391-1bdb2dd7-50ee-47ef-ab71-66b668f6fae0.gif)

**Note**: I didn't replicate the FlightMonitor component because we don't really need such level of complexity in this repo.
